### PR TITLE
feat: add models command and improve doctor model resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Prerequisites:
 - Node.js 20+
 - At least one LLM provider API key (ZAI, OpenAI, Anthropic, etc.)
 
+Useful discovery command:
+- `obora models <provider>` shows the model refs available from the installed `pi-ai` catalog
+  - examples: `obora models openai`, `obora models anthropic`, `obora --json models zai`
+
 What this path gives you:
 - `obora init --quickstart` creates a minimal judge-mode project
 - `obora doctor` shows ready/stub/missing-auth status and next actions

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,7 @@
 - [Exit Codes](#exit-codes)
 - [`obora init`](#obora-init)
 - [`obora quickstart`](#obora-quickstart)
+- [`obora models`](#obora-models)
 - [`obora doctor`](#obora-doctor)
 - [`obora run`](#obora-run)
 - [`obora test`](#obora-test)
@@ -82,6 +83,27 @@ obora quickstart my-project
 - Equivalent to `obora init [name] --quickstart`
 - Creates the same quickstart scaffold as `init --quickstart`
 - Intended as the shortest first-run command
+
+---
+
+## `obora models`
+
+List provider model refs from the installed `pi-ai` catalog.
+
+### Usage
+
+```bash
+obora models
+obora models openai
+obora --json models anthropic
+```
+
+### Behavior
+
+- uses the installed `@mariozechner/pi-ai` runtime catalog as the source of truth
+- without a provider, lists available providers and model counts
+- with a provider, lists the supported model refs for that provider
+- useful for choosing a valid `OPENAI_MODEL`, `ANTHROPIC_MODEL`, or `providers.<name>.defaultModel`
 
 ---
 

--- a/packages/adapters/src/llm/pi-ai-adapter.ts
+++ b/packages/adapters/src/llm/pi-ai-adapter.ts
@@ -21,6 +21,41 @@ import type {
   ToolDefinition,
 } from "./adapter";
 
+
+const PI_AI_PROVIDER_CANDIDATES = [
+  "openai",
+  "anthropic",
+  "google",
+  "zai",
+  "xai",
+  "groq",
+  "cerebras",
+  "openrouter",
+  "vercel-ai-gateway",
+  "mistral",
+  "minimax",
+  "minimax-cn",
+  "huggingface",
+  "opencode",
+  "kimi-coding",
+  "github-copilot",
+] as const;
+
+export function listPiAIProviders(): string[] {
+  return PI_AI_PROVIDER_CANDIDATES.filter((provider) => {
+    try {
+      return getModels(provider as KnownProvider).length > 0;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export function listPiAIModels(provider: string): string[] {
+  const models = getModels(provider as KnownProvider);
+  return models.map((model) => model.id);
+}
+
 interface PiAIAdapterConfig {
   provider: KnownProvider;
   apiKey: string;
@@ -143,8 +178,7 @@ export class PiAIAdapter implements LLMAdapter {
   }
 
   private listAvailableModels(): string {
-    const models = getModels(this.config.provider);
-    return models.map((model) => model.id).join(", ");
+    return listPiAIModels(this.config.provider).join(", ");
   }
 
   private withOverrides<TApi extends string>(model: Model<TApi>): Model<TApi> {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,7 @@ import { createDoctorCommand } from "./commands/doctor.js";
 import { createExpandCommand } from "./commands/expand.js";
 import { createInitCommand } from "./commands/init.js";
 import { createKnowledgeCommand } from "./commands/knowledge.js";
+import { createModelsCommand } from "./commands/models.js";
 import { createPluginCommand } from "./commands/plugin.js";
 import { createPolicyCommand } from "./commands/policy.js";
 import { createQuickstartCommand } from "./commands/quickstart.js";
@@ -53,6 +54,7 @@ export function createCLI(): Command {
 
   program.addCommand(createInitCommand());
   program.addCommand(createQuickstartCommand());
+  program.addCommand(createModelsCommand());
   program.addCommand(createDoctorCommand());
   program.addCommand(createExpandCommand());
   program.addCommand(createRunCommand());

--- a/packages/cli/src/commands/__tests__/cli-commands.test.ts
+++ b/packages/cli/src/commands/__tests__/cli-commands.test.ts
@@ -33,7 +33,16 @@ describe("M3 CLI command IA", () => {
     const names = cli.commands.map((command) => command.name());
 
     expect(names).toEqual(
-      expect.arrayContaining(["run", "test", "plugin", "audit", "policy", "init", "quickstart", "models"])
+      expect.arrayContaining([
+        "run",
+        "test",
+        "plugin",
+        "audit",
+        "policy",
+        "init",
+        "quickstart",
+        "models",
+      ])
     );
   });
 

--- a/packages/cli/src/commands/__tests__/cli-commands.test.ts
+++ b/packages/cli/src/commands/__tests__/cli-commands.test.ts
@@ -33,7 +33,7 @@ describe("M3 CLI command IA", () => {
     const names = cli.commands.map((command) => command.name());
 
     expect(names).toEqual(
-      expect.arrayContaining(["run", "test", "plugin", "audit", "policy", "init", "quickstart"])
+      expect.arrayContaining(["run", "test", "plugin", "audit", "policy", "init", "quickstart", "models"])
     );
   });
 

--- a/packages/cli/src/commands/__tests__/models.test.ts
+++ b/packages/cli/src/commands/__tests__/models.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable import/order */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@obora/adapters", () => ({
+  listPiAIProviders: vi.fn(() => ["openai", "anthropic"]),
+  listPiAIModels: vi.fn((provider: string) => {
+    if (provider === "openai") {
+      return ["gpt-4o-mini", "gpt-4o", "gpt-5"];
+    }
+    if (provider === "anthropic") {
+      return ["claude-3-7-sonnet-20250219"];
+    }
+    throw new Error(`Unsupported provider: ${provider}`);
+  }),
+}));
+
+vi.mock("../../utils/formatter.js", () => ({
+  formatter: {
+    success: vi.fn(),
+    json: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+  },
+}));
+
+vi.mock("../../utils/error-handler.js", () => ({
+  handleCommandAction: vi.fn(async (fn: () => Promise<void>) => {
+    await fn();
+  }),
+}));
+
+vi.mock("../../utils/global-opts.js", () => ({
+  getGlobalOpts: vi.fn(() => ({})),
+}));
+
+import { listPiAIModels, listPiAIProviders } from "@obora/adapters";
+
+import { formatter } from "../../utils/formatter.js";
+import { createModelsCommand, runModels } from "../models.js";
+
+describe("models command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates models command with correct name", () => {
+    const cmd = createModelsCommand();
+    expect(cmd.name()).toBe("models");
+  });
+
+  it("prints provider list in json mode when no provider is specified", async () => {
+    await runModels(undefined, { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      providers: [
+        { provider: "openai", count: 3 },
+        { provider: "anthropic", count: 1 },
+      ],
+    });
+  });
+
+  it("prints model list for a specific provider in text mode", async () => {
+    await runModels("openai", {});
+
+    expect(formatter.info).toHaveBeenCalledWith("Obora models");
+    expect(formatter.step).toHaveBeenCalledWith("Source: pi-ai");
+    expect(formatter.step).toHaveBeenCalledWith("Provider: openai");
+    expect(formatter.step).toHaveBeenCalledWith("Model count: 3");
+    expect(formatter.step).toHaveBeenCalledWith("gpt-4o-mini");
+    expect(formatter.step).toHaveBeenCalledWith("gpt-4o");
+    expect(formatter.step).toHaveBeenCalledWith("gpt-5");
+  });
+
+  it("prints model list for a specific provider in json mode", async () => {
+    await runModels("anthropic", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "anthropic",
+      count: 1,
+      models: ["claude-3-7-sonnet-20250219"],
+    });
+  });
+
+  it("throws a helpful error for unsupported providers", async () => {
+    await expect(runModels("unknown-provider", {})).rejects.toThrow(
+      "Unsupported provider 'unknown-provider'. Supported providers: openai, anthropic"
+    );
+  });
+
+  it("queries pi-ai provider catalog helpers", async () => {
+    await runModels("openai", {});
+
+    expect(listPiAIProviders).toHaveBeenCalled();
+    expect(listPiAIModels).toHaveBeenCalledWith("openai");
+  });
+});

--- a/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
+++ b/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
@@ -183,16 +183,21 @@ describe("CLI quickstart integration", () => {
     process.env.OPENAI_API_KEY = "test-openai-key";
     logSpy.mockClear();
     await cli.parseAsync(["--json", "doctor"], { from: "user" });
-    const missingModelPayload = lastJsonCall();
-    expect(missingModelPayload).toEqual(
+    const authOnlyPayload = lastJsonCall();
+    expect(authOnlyPayload).toEqual(
       expect.objectContaining({
         status: expect.objectContaining({
-          status: "needs_config",
-          message: "Needs model: provider auth detected but no model is resolved",
+          status: "ready",
+          message: "Ready: openai/gpt-4o-mini",
         }),
-        recommendations: expect.arrayContaining([
-          "Set a default model in .obora/config.yaml or export OPENAI_MODEL=***",
-        ]),
+        resolution: expect.objectContaining({
+          provider: "openai",
+          model: "gpt-4o-mini",
+          authSource: "env(OPENAI_API_KEY)",
+          modelSource: "config.defaults.model",
+          chosenByPrecedence: "env(auth) + config(model)",
+          fallbackStub: false,
+        }),
       })
     );
 

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,0 +1,79 @@
+import { listPiAIModels, listPiAIProviders } from "@obora/adapters";
+import { Command } from "commander";
+
+import { handleCommandAction } from "../utils/error-handler.js";
+import { formatter } from "../utils/formatter.js";
+import { getGlobalOpts } from "../utils/global-opts.js";
+
+interface ModelsOptions {
+  json?: boolean;
+}
+
+export async function runModels(provider: string | undefined, options: ModelsOptions): Promise<void> {
+  const providers = listPiAIProviders();
+
+  if (provider) {
+    if (!providers.includes(provider)) {
+      throw new Error(
+        `Unsupported provider '${provider}'. Supported providers: ${providers.join(", ")}`
+      );
+    }
+
+    const models = listPiAIModels(provider);
+
+    if (options.json) {
+      formatter.json({
+        source: "pi-ai",
+        provider,
+        count: models.length,
+        models,
+      });
+      return;
+    }
+
+    formatter.info("Obora models");
+    formatter.step("Source: pi-ai");
+    formatter.step(`Provider: ${provider}`);
+    formatter.step(`Model count: ${models.length}`);
+    for (const model of models) {
+      formatter.step(model);
+    }
+    return;
+  }
+
+  const providerRows = providers.map((name) => ({
+    provider: name,
+    count: listPiAIModels(name).length,
+  }));
+
+  if (options.json) {
+    formatter.json({
+      source: "pi-ai",
+      providers: providerRows,
+    });
+    return;
+  }
+
+  formatter.info("Obora models");
+  formatter.step("Source: pi-ai");
+  formatter.info("Providers");
+  for (const row of providerRows) {
+    formatter.step(`${row.provider} (${row.count})`);
+  }
+  formatter.info("Next step: obora models <provider>");
+}
+
+export function createModelsCommand(): Command {
+  return new Command("models")
+    .description("List supported model refs from the installed pi-ai catalog")
+    .argument("[provider]", "Provider name to inspect")
+    .action(async function (this: Command, provider?: string) {
+      const globalOpts = getGlobalOpts(this);
+      await handleCommandAction(
+        async () => {
+          await runModels(provider, globalOpts);
+        },
+        { verbose: Boolean(globalOpts.verbose) }
+      );
+    });
+}

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -9,7 +9,10 @@ interface ModelsOptions {
   json?: boolean;
 }
 
-export async function runModels(provider: string | undefined, options: ModelsOptions): Promise<void> {
+export async function runModels(
+  provider: string | undefined,
+  options: ModelsOptions
+): Promise<void> {
   const providers = listPiAIProviders();
 
   if (provider) {

--- a/packages/sdk/src/__tests__/llm-config.test.ts
+++ b/packages/sdk/src/__tests__/llm-config.test.ts
@@ -33,7 +33,7 @@ describe("llm-config", () => {
   });
 
   it("resolveLLMConfig priority: explicit > config > env", () => {
-    process.env.ANTHROPIC_API_KEY = "env-key";
+    process.env.ANTHROPIC_API_KEY="env-key";
 
     const fromExplicit = resolveLLMConfig(
       { provider: "openai", apiKey: "explicit-key", model: "gpt-5" },
@@ -42,7 +42,7 @@ describe("llm-config", () => {
         providers: {
           anthropic: { authRef: "plain-config-key", defaultModel: "claude-opus-4-6" },
         },
-      },
+      }
     );
     expect(fromExplicit?.provider).toBe("openai");
 
@@ -60,5 +60,25 @@ describe("llm-config", () => {
     expect(fromEnv?.apiKey).toBe("env-key");
 
     delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it("inherits config model when env auth is present for the configured provider", () => {
+    const resolved = resolveLLMConfig(
+      { provider: "openai", apiKey: "env-openai-key" },
+      {
+        defaults: { provider: "openai", model: "gpt-4o-mini" },
+        providers: {
+          openai: {},
+        },
+      }
+    );
+
+    expect(resolved).toEqual(
+      expect.objectContaining({
+        provider: "openai",
+        apiKey: "env-openai-key",
+        model: "gpt-4o-mini",
+      })
+    );
   });
 });

--- a/packages/sdk/src/llm-config.ts
+++ b/packages/sdk/src/llm-config.ts
@@ -58,9 +58,38 @@ export function detectLLMConfigFromEnv(env: NodeJS.ProcessEnv = process.env): LL
   return undefined;
 }
 
+function mergeExplicitWithConfig(explicit: LLMConfig, config?: OboraConfig): LLMConfig {
+  if (!config) {
+    return explicit;
+  }
+
+  const providerConfig = config.providers?.[explicit.provider];
+  const inheritedModel =
+    providerConfig?.defaultModel ??
+    (config.defaults?.provider === explicit.provider ? config.defaults?.model : undefined);
+  const inheritedTimeout =
+    providerConfig?.timeout ??
+    (config.defaults?.provider === explicit.provider ? config.defaults?.timeout : undefined);
+  const inheritedMaxTokens =
+    providerConfig?.maxTokens ??
+    (config.defaults?.provider === explicit.provider ? config.defaults?.maxTokens : undefined);
+  const inheritedTemperature =
+    config.defaults?.provider === explicit.provider ? config.defaults?.temperature : undefined;
+  const inheritedBaseUrl = providerConfig?.baseUrl;
+
+  return {
+    ...explicit,
+    model: explicit.model ?? inheritedModel,
+    timeout: explicit.timeout ?? inheritedTimeout,
+    maxTokens: explicit.maxTokens ?? inheritedMaxTokens,
+    temperature: explicit.temperature ?? inheritedTemperature,
+    baseUrl: explicit.baseUrl ?? inheritedBaseUrl,
+  };
+}
+
 export function resolveLLMConfig(explicit?: LLMConfig, config?: OboraConfig): LLMConfig | undefined {
   if (explicit) {
-    return explicit;
+    return mergeExplicitWithConfig(explicit, config);
   }
 
   if (config) {

--- a/packages/sdk/src/resolution-summary.ts
+++ b/packages/sdk/src/resolution-summary.ts
@@ -139,9 +139,22 @@ function inferAuthSource(runtimeConfig: OboraRuntimeConfig, llmConfig: LLMConfig
 }
 
 
-function inferChosenByPrecedence(runtimeConfig: OboraRuntimeConfig, config?: OboraConfig, llmConfig?: LLMConfig): string {
+function inferChosenByPrecedence(
+  runtimeConfig: OboraRuntimeConfig,
+  config?: OboraConfig,
+  llmConfig?: LLMConfig
+): string {
   if (!llmConfig) return "none";
+  const authSource = inferAuthSource(runtimeConfig, llmConfig, config);
+  const modelSource = inferModelSource(runtimeConfig, config, llmConfig);
   const resolvedSource = inferResolvedSource(runtimeConfig, config, llmConfig);
+
+  if (authSource === "runtime.llm" && modelSource.startsWith("config")) {
+    return "runtime.llm(auth) + config(model)";
+  }
+  if (authSource.startsWith("env(") && modelSource.startsWith("config")) {
+    return "env(auth) + config(model)";
+  }
   if (resolvedSource === "runtime") return "runtime.llm > config > env";
   if (resolvedSource === "env") return "env > config";
   if (resolvedSource === "config") return "config > env";


### PR DESCRIPTION
## Summary
- inherit config default models when auth is resolved from env so quickstart doctor/dry-run stays ready
- add `obora models` backed directly by the pi-ai provider catalog
- document the new models command in the README and CLI docs

## Test Plan
- pnpm --filter @obora/sdk test
- pnpm --filter @obora/cli test
- pnpm --filter @obora/adapters test
- pnpm --filter @obora/cli build
- pre-push review gate (typecheck/tests/sandbox smoke/build)

## Notes
- model listings intentionally use `pi-ai` as the single source of truth so adapter validation and CLI output stay aligned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an obora models command to list installed AI model references by provider, with human and JSON output.

* **Documentation**
  * Added docs and README examples showing how to use the models discovery command and example invocations.

* **Tests**
  * Added and updated CLI and SDK tests covering the new command and model/config resolution scenarios.

* **Bug Fixes / Behavior**
  * Improved config/model resolution to inherit configured defaults where appropriate, affecting model selection precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->