### PR TITLE
feat: add models query filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Prerequisites:
 - At least one LLM provider API key (ZAI, OpenAI, Anthropic, etc.)
 
 Useful discovery command:
-- `obora models <provider>` shows the model refs available from the installed `pi-ai` catalog
-  - examples: `obora models openai`, `obora models anthropic`, `obora --json models zai`
+- `obora models <provider> [query]` shows the model refs available from the installed `pi-ai` catalog
+  - examples: `obora models openai`, `obora models openai gpt-5.4`, `obora --json models zai glm-4.7`
 
 What this path gives you:
 - `obora init --quickstart` creates a minimal judge-mode project

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,7 +95,8 @@ List provider model refs from the installed `pi-ai` catalog.
 ```bash
 obora models
 obora models openai
-obora --json models anthropic
+obora models openai gpt-5.4
+obora --json models anthropic sonnet
 ```
 
 ### Behavior

--- a/packages/cli/src/commands/__tests__/models.test.ts
+++ b/packages/cli/src/commands/__tests__/models.test.ts
@@ -52,7 +52,7 @@ describe("models command", () => {
   });
 
   it("prints provider list in json mode when no provider is specified", async () => {
-    await runModels(undefined, { json: true });
+    await runModels(undefined, undefined, { json: true });
 
     expect(formatter.json).toHaveBeenCalledWith({
       source: "pi-ai",
@@ -64,7 +64,7 @@ describe("models command", () => {
   });
 
   it("prints model list for a specific provider in text mode", async () => {
-    await runModels("openai", {});
+    await runModels("openai", undefined, {});
 
     expect(formatter.info).toHaveBeenCalledWith("Obora models");
     expect(formatter.step).toHaveBeenCalledWith("Source: pi-ai");
@@ -76,7 +76,7 @@ describe("models command", () => {
   });
 
   it("prints model list for a specific provider in json mode", async () => {
-    await runModels("anthropic", { json: true });
+    await runModels("anthropic", undefined, { json: true });
 
     expect(formatter.json).toHaveBeenCalledWith({
       source: "pi-ai",
@@ -87,15 +87,38 @@ describe("models command", () => {
   });
 
   it("throws a helpful error for unsupported providers", async () => {
-    await expect(runModels("unknown-provider", {})).rejects.toThrow(
+    await expect(runModels("unknown-provider", undefined, {})).rejects.toThrow(
       "Unsupported provider 'unknown-provider'. Supported providers: openai, anthropic"
     );
   });
 
   it("queries pi-ai provider catalog helpers", async () => {
-    await runModels("openai", {});
+    await runModels("openai", undefined, {});
 
     expect(listPiAIProviders).toHaveBeenCalled();
     expect(listPiAIModels).toHaveBeenCalledWith("openai");
+  });
+
+  it("filters provider models by query in json mode", async () => {
+    await runModels("openai", "gpt-5", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "openai",
+      query: "gpt-5",
+      count: 1,
+      models: ["gpt-5"],
+    });
+  });
+
+  it("filters provider models by query in text mode", async () => {
+    await runModels("openai", "MINI", {});
+
+    expect(formatter.step).toHaveBeenCalledWith("Provider: openai");
+    expect(formatter.step).toHaveBeenCalledWith("Filter: MINI");
+    expect(formatter.step).toHaveBeenCalledWith("Model count: 1");
+    expect(formatter.step).toHaveBeenCalledWith("gpt-4o-mini");
+    expect(formatter.step).not.toHaveBeenCalledWith("gpt-4o");
+    expect(formatter.step).not.toHaveBeenCalledWith("gpt-5");
   });
 });

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -9,9 +9,19 @@ interface ModelsOptions {
   json?: boolean;
 }
 
+function filterModels(models: string[], query?: string): string[] {
+  if (!query) {
+    return models;
+  }
+
+  const normalizedQuery = query.toLowerCase();
+  return models.filter((model) => model.toLowerCase().includes(normalizedQuery));
+}
+
 export async function runModels(
   provider: string | undefined,
-  options: ModelsOptions
+  query: string | undefined,
+  options: ModelsOptions = {}
 ): Promise<void> {
   const providers = listPiAIProviders();
 
@@ -22,12 +32,13 @@ export async function runModels(
       );
     }
 
-    const models = listPiAIModels(provider);
+    const models = filterModels(listPiAIModels(provider), query);
 
     if (options.json) {
       formatter.json({
         source: "pi-ai",
         provider,
+        ...(query ? { query } : {}),
         count: models.length,
         models,
       });
@@ -37,6 +48,9 @@ export async function runModels(
     formatter.info("Obora models");
     formatter.step("Source: pi-ai");
     formatter.step(`Provider: ${provider}`);
+    if (query) {
+      formatter.step(`Filter: ${query}`);
+    }
     formatter.step(`Model count: ${models.length}`);
     for (const model of models) {
       formatter.step(model);
@@ -63,18 +77,19 @@ export async function runModels(
   for (const row of providerRows) {
     formatter.step(`${row.provider} (${row.count})`);
   }
-  formatter.info("Next step: obora models <provider>");
+  formatter.info("Next step: obora models <provider> [query]");
 }
 
 export function createModelsCommand(): Command {
   return new Command("models")
     .description("List supported model refs from the installed pi-ai catalog")
     .argument("[provider]", "Provider name to inspect")
-    .action(async function (this: Command, provider?: string) {
+    .argument("[query]", "Optional substring filter for model refs")
+    .action(async function (this: Command, provider?: string, query?: string) {
       const globalOpts = getGlobalOpts(this);
       await handleCommandAction(
         async () => {
-          await runModels(provider, globalOpts);
+          await runModels(provider, query, globalOpts);
         },
         { verbose: Boolean(globalOpts.verbose) }
       );


### PR DESCRIPTION
## Summary
- add an optional query argument to `obora models <provider> [query]`
- filter model refs with case-insensitive substring matching in text and json output
- document filtered model lookup examples in the README and CLI docs

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/models.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- manual smoke: `obora models openai gpt-5.4`
- manual smoke: `obora --json models openai mini`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `obora models` command now accepts an optional `[query]` argument to filter models by name.

* **Documentation**
  * Updated CLI documentation with examples demonstrating query-based model filtering (e.g., `obora models openai gpt-5.4`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->