### PR TITLE
feat: recommend latest models in doctor

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -10,6 +10,24 @@ vi.mock("@obora/sdk", () => ({
   formatResolutionSummary: vi.fn(),
 }));
 
+vi.mock("@obora/adapters", () => ({
+  listPiAIModels: vi.fn((provider: string) => {
+    if (provider === "openai") {
+      return ["gpt-5.4", "gpt-5", "gpt-5.4", "gpt-5.4-mini"];
+    }
+    if (provider === "anthropic") {
+      return ["claude-opus-4-20250514", "claude-opus-4-6", "claude-sonnet-4-6"];
+    }
+    if (provider === "zai") {
+      return ["glm-4.7", "glm-5", "glm-5-turbo"];
+    }
+    if (provider === "openrouter") {
+      return ["openai/gpt-5.4", "openai/gpt-5.4", "openai/gpt-5.4-mini"];
+    }
+    return [];
+  }),
+}));
+
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
 }));
@@ -39,6 +57,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { listPiAIModels } from "@obora/adapters";
 import {
   buildResolutionSummary,
   detectLLMConfigFromEnv,
@@ -140,7 +159,7 @@ describe("doctor command", () => {
     it("should include structured sections in json output", async () => {
       vi.mocked(buildResolutionSummary).mockReturnValue({
         provider: "openai",
-        model: "gpt-4o-mini",
+        model: "gpt-5.4",
         authSource: "env(OPENAI_API_KEY)",
         configSource: mockedConfigSource,
         modelSource: "config.defaults.model",
@@ -159,7 +178,7 @@ describe("doctor command", () => {
             status: expect.objectContaining({
               heading: "Status",
               status: "ready",
-              message: "Ready: openai/gpt-4o-mini",
+              message: "Ready: openai/gpt-5.4",
             }),
             configuration: expect.objectContaining({
               heading: "Configuration",
@@ -174,8 +193,8 @@ describe("doctor command", () => {
               heading: "Resolution",
               resolvedProvider: "openai",
               provider: "openai",
-              resolvedModel: "gpt-4o-mini",
-              model: "gpt-4o-mini",
+              resolvedModel: "gpt-5.4",
+              model: "gpt-5.4",
               modelSource: "config.defaults.model",
               chosenByPrecedence: "config > env",
               fallbackStub: false,
@@ -215,12 +234,12 @@ describe("doctor command", () => {
       vi.mocked(loadConfig).mockResolvedValue({
         defaults: {
           provider: "anthropic",
-          model: "claude-3-7-sonnet-latest",
+          model: "claude-opus-4-6",
         },
       });
       vi.mocked(buildResolutionSummary).mockReturnValue({
         provider: "openai",
-        model: "gpt-4o-mini",
+        model: "gpt-5.4",
         authSource: "env(OPENAI_API_KEY)",
         configSource: mockedConfigSource,
         modelSource: "env(OPENAI_MODEL)",
@@ -238,11 +257,11 @@ describe("doctor command", () => {
           sections: expect.objectContaining({
             configuration: expect.objectContaining({
               configuredProvider: "anthropic",
-              configuredModel: "claude-3-7-sonnet-latest",
+              configuredModel: "claude-opus-4-6",
             }),
             resolution: expect.objectContaining({
               resolvedProvider: "openai",
-              resolvedModel: "gpt-4o-mini",
+              resolvedModel: "gpt-5.4",
               modelSource: "env(OPENAI_MODEL)",
             }),
           }),
@@ -286,9 +305,28 @@ describe("doctor command", () => {
         expect.objectContaining({
           auth: expect.objectContaining({
             authExportExample: "export ANTHROPIC_API_KEY=***",
-            modelConfigExample:
-              "providers:\n  anthropic:\n    defaultModel: claude-3-7-sonnet-latest",
-            modelEnvExample: "export ANTHROPIC_MODEL=claude-3-7-sonnet-latest",
+            modelConfigExample: "providers:\n  anthropic:\n    defaultModel: claude-opus-4-6",
+            modelEnvExample: "export ANTHROPIC_MODEL=claude-opus-4-6",
+          }),
+        })
+      );
+    });
+
+    it("should infer latest provider model examples from pi-ai catalog", async () => {
+      vi.mocked(loadConfig).mockResolvedValue({
+        defaults: {
+          provider: "zai",
+        },
+      });
+
+      await runDoctor({ json: true });
+
+      expect(listPiAIModels).toHaveBeenCalledWith("zai");
+      expect(formatter.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          auth: expect.objectContaining({
+            modelConfigExample: "providers:\n  zai:\n    defaultModel: glm-5",
+            modelEnvExample: "export ZAI_MODEL=glm-5",
           }),
         })
       );
@@ -360,13 +398,13 @@ describe("doctor command", () => {
             resolvedAuthEnvKey: "OPENAI_API_KEY",
             resolvedModelEnvKey: "OPENAI_MODEL",
             resolvedAuthExportExample: "export OPENAI_API_KEY=***",
-            resolvedModelEnvExample: "export OPENAI_MODEL=gpt-4o-mini",
-            resolvedModelConfigExample: "providers:\n  openai:\n    defaultModel: gpt-4o-mini",
+            resolvedModelEnvExample: "export OPENAI_MODEL=gpt-5.4",
+            resolvedModelConfigExample: "providers:\n  openai:\n    defaultModel: gpt-5.4",
           }),
           recommendations: expect.arrayContaining([
             "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
-            "Resolved provider model config example: providers:\n  openai:\n    defaultModel: gpt-4o-mini",
-            "Resolved provider model env example: export OPENAI_MODEL=gpt-4o-mini",
+            "Resolved provider model config example: providers:\n  openai:\n    defaultModel: gpt-5.4",
+            "Resolved provider model env example: export OPENAI_MODEL=gpt-5.4",
           ]),
         })
       );
@@ -479,7 +517,7 @@ describe("doctor command", () => {
     it("should report ready status when provider and model are resolved", async () => {
       vi.mocked(buildResolutionSummary).mockReturnValue({
         provider: "openai",
-        model: "gpt-4o-mini",
+        model: "gpt-5.4",
         authSource: "env(OPENAI_API_KEY)",
         configSource: ".obora/config.yaml",
         modelSource: "config.defaults.model",
@@ -492,9 +530,9 @@ describe("doctor command", () => {
 
       await runDoctor({});
 
-      expect(formatter.step).toHaveBeenCalledWith("Ready: openai/gpt-4o-mini");
+      expect(formatter.step).toHaveBeenCalledWith("Ready: openai/gpt-5.4");
       expect(formatter.step).toHaveBeenCalledWith("Resolved provider: openai");
-      expect(formatter.step).toHaveBeenCalledWith("Resolved model: gpt-4o-mini");
+      expect(formatter.step).toHaveBeenCalledWith("Resolved model: gpt-5.4");
       expect(formatter.step).toHaveBeenCalledWith("Fallback/stub: disabled");
       expect(formatter.step).toHaveBeenCalledWith("Run your workflow: obora run judge.yaml");
     });

--- a/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
+++ b/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
@@ -221,11 +221,11 @@ describe("CLI quickstart integration", () => {
           resolvedProvider: "openai",
           providerMismatchWarning:
             "Configured provider 'anthropic' differs from detected env auth providers: openai",
-          resolvedModelEnvExample: "export OPENAI_MODEL=gpt-4o-mini",
+          resolvedModelEnvExample: "export OPENAI_MODEL=gpt-5.4",
         }),
         recommendations: expect.arrayContaining([
           "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
-          "Resolved provider model env example: export OPENAI_MODEL=gpt-4o-mini",
+          "Resolved provider model env example: export OPENAI_MODEL=gpt-5.4",
         ]),
       })
     );
@@ -311,9 +311,7 @@ describe("CLI quickstart integration", () => {
     expect(stdout).toContain("Resolution");
     expect(stdout).toContain("Configured provider: anthropic");
     expect(stdout).toContain("Resolved provider: openai");
-    expect(stdout).toContain(
-      "Resolved provider model env example: export OPENAI_MODEL=gpt-4o-mini"
-    );
+    expect(stdout).toContain("Resolved provider model env example: export OPENAI_MODEL=gpt-5.4");
     expect(stderr).toContain(
       "Configured provider 'anthropic' differs from detected env auth providers: openai"
     );

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { listPiAIModels } from "@obora/adapters";
 import {
   buildResolutionSummary,
   detectLLMConfigFromEnv,
@@ -151,11 +152,156 @@ const PROVIDER_AUTH_ENV_KEY_MAP: Record<string, string> = {
 };
 
 const PROVIDER_DEFAULT_MODEL_MAP: Record<string, string> = {
-  anthropic: "claude-3-7-sonnet-latest",
-  openai: "gpt-4o-mini",
-  openrouter: "openai/gpt-4o-mini",
-  zai: "glm-4.7",
+  anthropic: "claude-opus-4-6",
+  openai: "gpt-5.4",
+  openrouter: "openai/gpt-5.4",
+  zai: "glm-5",
 };
+
+function selectOpenAILatestModel(models: string[]): string | undefined {
+  const scored = models
+    .map((model) => {
+      const match = /^gpt-(\d+)(?:\.(\d+))?$/.exec(model);
+      if (!match) return null;
+      return {
+        model,
+        major: Number(match[1] ?? 0),
+        minor: Number(match[2] ?? 0),
+      };
+    })
+    .filter((entry): entry is { model: string; major: number; minor: number } => entry !== null)
+    .sort((left, right) => right.major - left.major || right.minor - left.minor);
+
+  return scored[0]?.model;
+}
+
+interface AnthropicModelScore {
+  model: string;
+  family: number;
+  major: number;
+  minor: number;
+  stableAlias: boolean;
+  snapshotDate: number;
+}
+
+function parseAnthropicModel(
+  model: string,
+  familyPriority: Record<string, number>
+): AnthropicModelScore | null {
+  const modernMatch = /^claude-(opus|sonnet|haiku)-(\d+)-(\d+)(?:-(\d{8}))?$/.exec(model);
+  if (modernMatch) {
+    const major = Number(modernMatch[2] ?? 0);
+    const thirdToken = modernMatch[3] ?? "0";
+    const snapshotDate = modernMatch[4] ? Number(modernMatch[4]) : 0;
+
+    if (!modernMatch[4] && thirdToken.length === 8) {
+      return {
+        model,
+        family: familyPriority[modernMatch[1] ?? ""] ?? 0,
+        major,
+        minor: 0,
+        stableAlias: false,
+        snapshotDate: Number(thirdToken),
+      };
+    }
+
+    return {
+      model,
+      family: familyPriority[modernMatch[1] ?? ""] ?? 0,
+      major,
+      minor: Number(thirdToken),
+      stableAlias: !modernMatch[4],
+      snapshotDate,
+    };
+  }
+
+  const legacyMatch = /^claude-(\d+)-(\d+)-(opus|sonnet|haiku)(?:-(latest|\d{8}))?$/.exec(model);
+  if (!legacyMatch) {
+    return null;
+  }
+
+  return {
+    model,
+    family: familyPriority[legacyMatch[3] ?? ""] ?? 0,
+    major: Number(legacyMatch[1] ?? 0),
+    minor: Number(legacyMatch[2] ?? 0),
+    stableAlias: !legacyMatch[4] || legacyMatch[4] === "latest",
+    snapshotDate: legacyMatch[4] && legacyMatch[4] !== "latest" ? Number(legacyMatch[4]) : 0,
+  };
+}
+
+function selectAnthropicLatestModel(models: string[]): string | undefined {
+  const familyPriority: Record<string, number> = {
+    opus: 3,
+    sonnet: 2,
+    haiku: 1,
+  };
+
+  const scored = models
+    .map((model) => parseAnthropicModel(model, familyPriority))
+    .filter((entry): entry is AnthropicModelScore => entry !== null)
+    .sort(
+      (left, right) =>
+        right.family - left.family ||
+        right.major - left.major ||
+        right.minor - left.minor ||
+        Number(right.stableAlias) - Number(left.stableAlias) ||
+        right.snapshotDate - left.snapshotDate
+    );
+
+  return scored[0]?.model;
+}
+
+function selectZAILatestModel(models: string[]): string | undefined {
+  const scored = models
+    .map((model) => {
+      const match = /^glm-(\d+)(?:\.(\d+))?$/.exec(model);
+      if (!match) return null;
+      return {
+        model,
+        major: Number(match[1] ?? 0),
+        minor: Number(match[2] ?? 0),
+      };
+    })
+    .filter((entry): entry is { model: string; major: number; minor: number } => entry !== null)
+    .sort((left, right) => right.major - left.major || right.minor - left.minor);
+
+  return scored[0]?.model;
+}
+
+function selectOpenRouterLatestModel(models: string[]): string | undefined {
+  const openaiModels = models.filter((model) => model.startsWith("openai/"));
+  const selectedOpenAI = selectOpenAILatestModel(
+    openaiModels.map((model) => model.replace(/^openai\//, ""))
+  );
+  return selectedOpenAI ? `openai/${selectedOpenAI}` : undefined;
+}
+
+function inferLatestCatalogModel(provider: string): string | undefined {
+  let models: string[];
+  try {
+    models = listPiAIModels(provider);
+  } catch {
+    return undefined;
+  }
+
+  if (models.length === 0) {
+    return undefined;
+  }
+
+  switch (provider) {
+    case "openai":
+      return selectOpenAILatestModel(models);
+    case "anthropic":
+      return selectAnthropicLatestModel(models);
+    case "zai":
+      return selectZAILatestModel(models);
+    case "openrouter":
+      return selectOpenRouterLatestModel(models);
+    default:
+      return undefined;
+  }
+}
 
 function inferAuthEnvKey(provider: string): string {
   return (
@@ -172,7 +318,9 @@ function inferModelEnvKey(provider: string): string {
 }
 
 function inferDefaultModel(provider: string): string {
-  return PROVIDER_DEFAULT_MODEL_MAP[provider] ?? "your-model-name";
+  return (
+    inferLatestCatalogModel(provider) ?? PROVIDER_DEFAULT_MODEL_MAP[provider] ?? "your-model-name"
+  );
 }
 
 function buildProviderSetupExamples(provider: string | null): ProviderSetupExamples {


### PR DESCRIPTION
## Summary
- update doctor model setup recommendations to prefer latest catalog-backed provider models
- handle Anthropic dated snapshot refs without overriding stable semantic aliases
- refresh doctor/quickstart expectations and add regression coverage

## Test Plan
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- manual `node packages/cli/bin/obora.js --json doctor` smoke for openai/anthropic/zai
- independent reviewer subagent pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor command now dynamically infers the latest available model from each provider's catalog instead of using fixed defaults.
  * Added support for ZAI provider with automatic latest model detection.

* **Bug Fixes**
  * Updated default AI models to newer versions across providers (OpenAI, Anthropic, OpenRouter).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->