### PR TITLE
feat: add global model search

### DIFF
--- a/packages/cli/src/commands/__tests__/models.test.ts
+++ b/packages/cli/src/commands/__tests__/models.test.ts
@@ -6,10 +6,10 @@ vi.mock("@obora/adapters", () => ({
   listPiAIProviders: vi.fn(() => ["openai", "anthropic"]),
   listPiAIModels: vi.fn((provider: string) => {
     if (provider === "openai") {
-      return ["gpt-4o-mini", "gpt-4o", "gpt-5"];
+      return ["gpt-4o-mini", "gpt-4o", "gpt-5", "gpt-5.4"];
     }
     if (provider === "anthropic") {
-      return ["claude-3-7-sonnet-20250219"];
+      return ["claude-3-7-sonnet-20250219", "claude-opus-4-6"];
     }
     throw new Error(`Unsupported provider: ${provider}`);
   }),
@@ -57,10 +57,35 @@ describe("models command", () => {
     expect(formatter.json).toHaveBeenCalledWith({
       source: "pi-ai",
       providers: [
-        { provider: "openai", count: 3 },
-        { provider: "anthropic", count: 1 },
+        { provider: "openai", count: 4 },
+        { provider: "anthropic", count: 2 },
       ],
     });
+  });
+
+  it("treats an unknown first arg as global query in json mode", async () => {
+    await runModels("gpt-5", undefined, { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      query: "gpt-5",
+      count: 2,
+      matches: [
+        { provider: "openai", model: "gpt-5" },
+        { provider: "openai", model: "gpt-5.4" },
+      ],
+    });
+  });
+
+  it("treats an unknown first arg as global query in text mode", async () => {
+    await runModels("claude", undefined, {});
+
+    expect(formatter.info).toHaveBeenCalledWith("Obora models");
+    expect(formatter.step).toHaveBeenCalledWith("Source: pi-ai");
+    expect(formatter.step).toHaveBeenCalledWith("Global filter: claude");
+    expect(formatter.step).toHaveBeenCalledWith("Match count: 2");
+    expect(formatter.step).toHaveBeenCalledWith("anthropic: claude-3-7-sonnet-20250219");
+    expect(formatter.step).toHaveBeenCalledWith("anthropic: claude-opus-4-6");
   });
 
   it("prints model list for a specific provider in text mode", async () => {
@@ -69,7 +94,7 @@ describe("models command", () => {
     expect(formatter.info).toHaveBeenCalledWith("Obora models");
     expect(formatter.step).toHaveBeenCalledWith("Source: pi-ai");
     expect(formatter.step).toHaveBeenCalledWith("Provider: openai");
-    expect(formatter.step).toHaveBeenCalledWith("Model count: 3");
+    expect(formatter.step).toHaveBeenCalledWith("Model count: 4");
     expect(formatter.step).toHaveBeenCalledWith("gpt-4o-mini");
     expect(formatter.step).toHaveBeenCalledWith("gpt-4o");
     expect(formatter.step).toHaveBeenCalledWith("gpt-5");
@@ -81,13 +106,19 @@ describe("models command", () => {
     expect(formatter.json).toHaveBeenCalledWith({
       source: "pi-ai",
       provider: "anthropic",
-      count: 1,
-      models: ["claude-3-7-sonnet-20250219"],
+      count: 2,
+      models: ["claude-3-7-sonnet-20250219", "claude-opus-4-6"],
     });
   });
 
-  it("throws a helpful error for unsupported providers", async () => {
-    await expect(runModels("unknown-provider", undefined, {})).rejects.toThrow(
+  it("throws a helpful error for unsupported providers when a provider filter is explicit", async () => {
+    await expect(runModels("unknown-provider", "mini", {})).rejects.toThrow(
+      "Unsupported provider 'unknown-provider'. Supported providers: openai, anthropic"
+    );
+  });
+
+  it("throws a helpful error for unsupported providers when an empty explicit query is supplied", async () => {
+    await expect(runModels("unknown-provider", "", {})).rejects.toThrow(
       "Unsupported provider 'unknown-provider'. Supported providers: openai, anthropic"
     );
   });
@@ -106,8 +137,8 @@ describe("models command", () => {
       source: "pi-ai",
       provider: "openai",
       query: "gpt-5",
-      count: 1,
-      models: ["gpt-5"],
+      count: 2,
+      models: ["gpt-5", "gpt-5.4"],
     });
   });
 

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -9,6 +9,11 @@ interface ModelsOptions {
   json?: boolean;
 }
 
+interface GlobalModelMatch {
+  provider: string;
+  model: string;
+}
+
 function filterModels(models: string[], query?: string): string[] {
   if (!query) {
     return models;
@@ -18,6 +23,39 @@ function filterModels(models: string[], query?: string): string[] {
   return models.filter((model) => model.toLowerCase().includes(normalizedQuery));
 }
 
+function buildGlobalMatches(providers: string[], query: string): GlobalModelMatch[] {
+  return providers.flatMap((provider) =>
+    filterModels(listPiAIModels(provider), query).map((model) => ({
+      provider,
+      model,
+    }))
+  );
+}
+
+function printGlobalMatches(
+  matches: GlobalModelMatch[],
+  query: string,
+  options: ModelsOptions
+): void {
+  if (options.json) {
+    formatter.json({
+      source: "pi-ai",
+      query,
+      count: matches.length,
+      matches,
+    });
+    return;
+  }
+
+  formatter.info("Obora models");
+  formatter.step("Source: pi-ai");
+  formatter.step(`Global filter: ${query}`);
+  formatter.step(`Match count: ${matches.length}`);
+  for (const match of matches) {
+    formatter.step(`${match.provider}: ${match.model}`);
+  }
+}
+
 export async function runModels(
   provider: string | undefined,
   query: string | undefined,
@@ -25,13 +63,18 @@ export async function runModels(
 ): Promise<void> {
   const providers = listPiAIProviders();
 
-  if (provider) {
-    if (!providers.includes(provider)) {
+  if (provider && !providers.includes(provider)) {
+    if (query !== undefined) {
       throw new Error(
         `Unsupported provider '${provider}'. Supported providers: ${providers.join(", ")}`
       );
     }
 
+    printGlobalMatches(buildGlobalMatches(providers, provider), provider, options);
+    return;
+  }
+
+  if (provider) {
     const models = filterModels(listPiAIModels(provider), query);
 
     if (options.json) {
@@ -77,14 +120,14 @@ export async function runModels(
   for (const row of providerRows) {
     formatter.step(`${row.provider} (${row.count})`);
   }
-  formatter.info("Next step: obora models <provider> [query]");
+  formatter.info("Next step: obora models <provider> [query] or obora models <query>");
 }
 
 export function createModelsCommand(): Command {
   return new Command("models")
     .description("List supported model refs from the installed pi-ai catalog")
-    .argument("[provider]", "Provider name to inspect")
-    .argument("[query]", "Optional substring filter for model refs")
+    .argument("[provider]", "Provider name to inspect or global query")
+    .argument("[query]", "Optional substring filter for provider-specific model refs")
     .action(async function (this: Command, provider?: string, query?: string) {
       const globalOpts = getGlobalOpts(this);
       await handleCommandAction(


### PR DESCRIPTION
## Summary
- allow `obora models <query>` to search model refs across all providers
- keep provider-specific filtering unchanged and preserve explicit unsupported-provider errors
- add regression coverage for global JSON/text output and empty-query edge cases

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/models.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- manual `node packages/cli/bin/obora.js --json models gpt-5.4`
- manual `node packages/cli/bin/obora.js models claude-opus-4-6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global model search functionality allows queries across all providers simultaneously without provider specification
  
* **Improvements**
  * Invalid provider names now interpreted as global queries instead of throwing unsupported provider errors
  * Model catalog expanded with additional provider models
  * CLI argument descriptions updated to clarify dual-purpose first argument (provider name or global query)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->