### PR TITLE
feat: add model zero-match hints

### DIFF
--- a/packages/cli/src/commands/__tests__/models.test.ts
+++ b/packages/cli/src/commands/__tests__/models.test.ts
@@ -88,6 +88,16 @@ describe("models command", () => {
     expect(formatter.step).toHaveBeenCalledWith("anthropic: claude-opus-4-6");
   });
 
+  it("prints a helpful hint when global search returns no matches in text mode", async () => {
+    await runModels("not-a-real-model", undefined, {});
+
+    expect(formatter.step).toHaveBeenCalledWith("Global filter: not-a-real-model");
+    expect(formatter.step).toHaveBeenCalledWith("Match count: 0");
+    expect(formatter.warn).toHaveBeenCalledWith(
+      "No models matched. Check the spelling or try `obora models <provider> [query]`."
+    );
+  });
+
   it("prints model list for a specific provider in text mode", async () => {
     await runModels("openai", undefined, {});
 
@@ -139,6 +149,71 @@ describe("models command", () => {
       query: "gpt-5",
       count: 2,
       models: ["gpt-5", "gpt-5.4"],
+    });
+  });
+
+  it("prints a helpful hint when provider filter returns no matches in json mode", async () => {
+    await runModels("openai", "not-a-real-model", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "openai",
+      query: "not-a-real-model",
+      count: 0,
+      models: [],
+      hint: "No models matched this provider filter. Check the query spelling or run `obora models 'not-a-real-model'`.",
+    });
+  });
+
+  it("uses a generic provider zero-match hint when the query is also a provider name", async () => {
+    await runModels("openai", "anthropic", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "openai",
+      query: "anthropic",
+      count: 0,
+      models: [],
+      hint: "No models matched this provider filter. Check the query spelling or search across all providers instead.",
+    });
+  });
+
+  it("uses the same generic hint for mixed-case provider-name queries", async () => {
+    await runModels("openai", "Anthropic", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "openai",
+      query: "Anthropic",
+      count: 0,
+      models: [],
+      hint: "No models matched this provider filter. Check the query spelling or search across all providers instead.",
+    });
+  });
+
+  it("quotes multi-word provider filter hints so the suggested command stays valid", async () => {
+    await runModels("openai", "claude opus", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "openai",
+      query: "claude opus",
+      count: 0,
+      models: [],
+      hint: "No models matched this provider filter. Check the query spelling or run `obora models 'claude opus'`.",
+    });
+  });
+
+  it("shell-quotes special characters in provider zero-match fallback commands", async () => {
+    await runModels("openai", "price $HOME", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "openai",
+      query: "price $HOME",
+      count: 0,
+      models: [],
+      hint: "No models matched this provider filter. Check the query spelling or run `obora models 'price $HOME'`.",
     });
   });
 

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -14,6 +14,24 @@ interface GlobalModelMatch {
   model: string;
 }
 
+function buildGlobalNoMatchHint(): string {
+  return `No models matched. Check the spelling or try \`obora models <provider> [query]\`.`;
+}
+
+function shellQuoteArg(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function buildProviderNoMatchHint(query: string, providers: string[]): string {
+  const normalizedQuery = query.toLowerCase();
+  if (providers.some((provider) => provider.toLowerCase() == normalizedQuery)) {
+    return "No models matched this provider filter. Check the query spelling or search across all providers instead.";
+  }
+
+  const suggestedQuery = shellQuoteArg(query);
+  return `No models matched this provider filter. Check the query spelling or run \`obora models ${suggestedQuery}\`.`;
+}
+
 function filterModels(models: string[], query?: string): string[] {
   if (!query) {
     return models;
@@ -43,6 +61,7 @@ function printGlobalMatches(
       query,
       count: matches.length,
       matches,
+      ...(matches.length === 0 ? { hint: buildGlobalNoMatchHint() } : {}),
     });
     return;
   }
@@ -51,6 +70,11 @@ function printGlobalMatches(
   formatter.step("Source: pi-ai");
   formatter.step(`Global filter: ${query}`);
   formatter.step(`Match count: ${matches.length}`);
+  if (matches.length === 0) {
+    formatter.warn(buildGlobalNoMatchHint());
+    return;
+  }
+
   for (const match of matches) {
     formatter.step(`${match.provider}: ${match.model}`);
   }
@@ -84,6 +108,9 @@ export async function runModels(
         ...(query ? { query } : {}),
         count: models.length,
         models,
+        ...(models.length === 0 && query
+          ? { hint: buildProviderNoMatchHint(query, providers) }
+          : {}),
       });
       return;
     }
@@ -95,6 +122,11 @@ export async function runModels(
       formatter.step(`Filter: ${query}`);
     }
     formatter.step(`Model count: ${models.length}`);
+    if (models.length === 0 && query) {
+      formatter.warn(buildProviderNoMatchHint(query, providers));
+      return;
+    }
+
     for (const model of models) {
       formatter.step(model);
     }


### PR DESCRIPTION
## Summary
- add zero-match hints for global and provider-filter `models` results
- avoid misleading fallback commands for provider-name queries
- shell-quote fallback command suggestions and add regression coverage

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/models.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- manual `node packages/cli/bin/obora.js models not-a-real-model`
- manual `node packages/cli/bin/obora.js --json models openai not-a-real-model`
- manual `node packages/cli/bin/obora.js --json models openai Anthropic`
- manual `node packages/cli/bin/obora.js --json models openai 'price $HOME'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the `models` command with improved messaging when searches return no results. Now provides contextual hints for both global searches and provider-filtered queries, including smart suggestions for correcting common syntax errors and exploring alternative providers across both text and JSON output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->