### PR TITLE
feat(cli): add direct doctor mismatch fixes

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -536,6 +536,8 @@ describe("doctor command", () => {
           }),
           recommendations: expect.arrayContaining([
             "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
+            "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL",
+            "Switch config default provider: edit .obora/config.yaml and set defaults.provider: openai",
             "Resolved provider model config example: providers:\n  openai:\n    defaultModel: gpt-5.4",
             "Resolved provider model env example: export OPENAI_MODEL=gpt-5.4",
             "Resolved provider model recommendation basis: pi-ai catalog latest GPT base model for openai",

--- a/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
+++ b/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
@@ -225,6 +225,10 @@ describe("CLI quickstart integration", () => {
         }),
         recommendations: expect.arrayContaining([
           "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
+          "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL",
+          expect.stringContaining(
+            "contract-demo/.obora/config.yaml and set defaults.provider: openai"
+          ),
           "Resolved provider model env example: export OPENAI_MODEL=gpt-5.4",
         ]),
       })
@@ -311,6 +315,12 @@ describe("CLI quickstart integration", () => {
     expect(stdout).toContain("Resolution");
     expect(stdout).toContain("Configured provider: anthropic");
     expect(stdout).toContain("Resolved provider: openai");
+    expect(stdout).toContain(
+      "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL"
+    );
+    expect(stdout).toContain(
+      "doctor-stdout-demo/.obora/config.yaml and set defaults.provider: openai"
+    );
     expect(stdout).toContain("Resolved provider model env example: export OPENAI_MODEL=gpt-5.4");
     expect(stderr).toContain(
       "Configured provider 'anthropic' differs from detected env auth providers: openai"

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -592,19 +592,44 @@ function buildConfiguredProviderHints(providerHint: DoctorProviderHint): string[
   ];
 }
 
-function buildResolvedProviderMismatchRecommendation(
-  summary: { provider: string | null },
-  providerHint: DoctorProviderHint
-): string | null {
+function isConfigFilePath(path: string): boolean {
+  return /\.(ya?ml)$/i.test(path);
+}
+
+function buildResolvedProviderMismatchRecommendations(
+  summary: { provider: string | null; nextPlaceToEdit: string },
+  providerHint: DoctorProviderHint,
+  authDiagnostics: DoctorAuthDiagnostics
+): string[] {
   if (!summary.provider || !providerHint.configuredProvider) {
-    return null;
+    return [];
   }
 
   if (summary.provider === providerHint.configuredProvider) {
-    return null;
+    return [];
   }
 
-  return `Resolved provider does not match configured provider. Either export ${inferAuthEnvKey(providerHint.configuredProvider)}=*** or switch defaults.provider to ${summary.provider}`;
+  const recommendations = [
+    `Resolved provider does not match configured provider. Either export ${inferAuthEnvKey(providerHint.configuredProvider)}=*** or switch defaults.provider to ${summary.provider}`,
+  ];
+
+  const envKeysToUnset = [
+    authDiagnostics.resolvedAuthEnvKey,
+    authDiagnostics.resolvedModelEnvKey,
+  ].filter((key): key is string => Boolean(key));
+  if (envKeysToUnset.length > 0) {
+    recommendations.push(
+      `Use configured provider in this shell: unset ${Array.from(new Set(envKeysToUnset)).join(" ")}`
+    );
+  }
+
+  if (isConfigFilePath(summary.nextPlaceToEdit)) {
+    recommendations.push(
+      `Switch config default provider: edit ${summary.nextPlaceToEdit} and set defaults.provider: ${summary.provider}`
+    );
+  }
+
+  return recommendations;
 }
 
 function buildProviderSpecificGuidance(
@@ -709,6 +734,7 @@ function buildDoctorRecommendations(
     model: string | null;
     authSource: string;
     configSource: string;
+    nextPlaceToEdit: string;
     fallbackStub: boolean;
     warnings: string[];
   },
@@ -736,14 +762,9 @@ function buildDoctorRecommendations(
     }
   }
 
-  const resolvedProviderMismatchRecommendation = buildResolvedProviderMismatchRecommendation(
-    summary,
-    providerHint,
-    authDiagnostics
+  recommendations.push(
+    ...buildResolvedProviderMismatchRecommendations(summary, providerHint, authDiagnostics)
   );
-  if (resolvedProviderMismatchRecommendation) {
-    recommendations.push(resolvedProviderMismatchRecommendation);
-  }
 
   recommendations.push(...buildProviderSpecificGuidance(summary, authDiagnostics));
 


### PR DESCRIPTION
## Summary
- add direct fix actions for doctor provider mismatch guidance
- show shell cleanup guidance for resolved provider env overrides
- point directly to the config file and defaults.provider change when a config path is available
- extend doctor and quickstart e2e coverage for the new mismatch guidance

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/doctor.test.ts src/commands/__tests__/quickstart-e2e.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- manual smoke: doctor mismatch output with anthropic config + OPENAI_API_KEY env


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced the doctor command's troubleshooting recommendations when configured and detected providers mismatch. The command now provides actionable guidance, including instructions to unset conflicting environment variables and specific steps to update your default provider configuration through the config file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->