### PR TITLE
feat(cli): add auth mismatch doctor fixes

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -482,6 +482,10 @@ describe("doctor command", () => {
           }),
           recommendations: expect.arrayContaining([
             "Detected env auth does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to one of: openai",
+            "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL",
+            expect.stringContaining(
+              "packages/cli/.obora/config.yaml and set defaults.provider: openai"
+            ),
           ]),
         })
       );

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -592,6 +592,43 @@ function buildConfiguredProviderHints(providerHint: DoctorProviderHint): string[
   ];
 }
 
+function buildDetectedProviderMismatchRecommendations(
+  checks: DoctorChecks,
+  providerHint: DoctorProviderHint,
+  authDiagnostics: DoctorAuthDiagnostics
+): string[] {
+  if (!authDiagnostics.providerMismatchWarning || !providerHint.recommendedAuthEnvKey) {
+    return [];
+  }
+
+  const recommendations = [
+    `Detected env auth does not match configured provider. Either export ${providerHint.recommendedAuthEnvKey}=*** or switch defaults.provider to one of: ${authDiagnostics.detectedProviders.join(", ")}`,
+  ];
+
+  const envKeysToUnset = authDiagnostics.detectedProviders.flatMap((provider) => {
+    const keys = [inferAuthEnvKey(provider)];
+    const modelEnvKey = PROVIDER_MODEL_ENV_KEY_MAP[provider];
+    if (modelEnvKey) {
+      keys.push(modelEnvKey);
+    }
+    return keys;
+  });
+
+  if (envKeysToUnset.length > 0) {
+    recommendations.push(
+      `Use configured provider in this shell: unset ${Array.from(new Set(envKeysToUnset)).join(" ")}`
+    );
+  }
+
+  if (authDiagnostics.detectedProviders.length === 1) {
+    recommendations.push(
+      `Switch config default provider: edit ${checks.projectConfigPath} and set defaults.provider: ${authDiagnostics.detectedProviders[0]}`
+    );
+  }
+
+  return recommendations;
+}
+
 function isConfigFilePath(path: string): boolean {
   return /\.(ya?ml)$/i.test(path);
 }
@@ -755,11 +792,9 @@ function buildDoctorRecommendations(
     if (authExampleHint) {
       recommendations.push(authExampleHint);
     }
-    if (authDiagnostics.providerMismatchWarning && providerHint.recommendedAuthEnvKey) {
-      recommendations.push(
-        `Detected env auth does not match configured provider. Either export ${providerHint.recommendedAuthEnvKey}=*** or switch defaults.provider to one of: ${authDiagnostics.detectedProviders.join(", ")}`
-      );
-    }
+    recommendations.push(
+      ...buildDetectedProviderMismatchRecommendations(checks, providerHint, authDiagnostics)
+    );
   }
 
   recommendations.push(


### PR DESCRIPTION
## Summary
- add direct fix actions for detected auth mismatch guidance in doctor
- suggest unsetting conflicting env vars when configured provider should win
- suggest switching defaults.provider directly when a single detected env provider is present
- extend doctor tests to lock the new mismatch actions

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/doctor.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced the doctor command to provide more detailed recommendations when a provider configuration mismatch is detected. Users now receive actionable guidance including shell commands to unset conflicting environment variables and instructions to update the configuration file with the correct provider setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->