### PR TITLE
feat(cli): summarize doctor provider conflicts

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -479,6 +479,8 @@ describe("doctor command", () => {
           auth: expect.objectContaining({
             providerMismatchWarning:
               "Configured provider 'anthropic' differs from detected env auth providers: openai",
+            conflictSummary:
+              "configured provider anthropic, detected env auth openai, resolved provider none",
           }),
           recommendations: expect.arrayContaining([
             "Detected env auth does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to one of: openai",
@@ -503,6 +505,9 @@ describe("doctor command", () => {
 
       expect(formatter.warn).toHaveBeenCalledWith(
         "Configured provider 'anthropic' differs from detected env auth providers: openai"
+      );
+      expect(formatter.warn).toHaveBeenCalledWith(
+        "Conflict summary: configured provider anthropic, detected env auth openai, resolved provider none"
       );
     });
 
@@ -537,6 +542,8 @@ describe("doctor command", () => {
             resolvedModelEnvExample: "export OPENAI_MODEL=gpt-5.4",
             resolvedModelConfigExample: "providers:\n  openai:\n    defaultModel: gpt-5.4",
             resolvedModelRecommendationReason: "pi-ai catalog latest GPT base model for openai",
+            conflictSummary:
+              "configured provider anthropic, detected env auth openai, resolved provider openai",
           }),
           recommendations: expect.arrayContaining([
             "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",

--- a/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
+++ b/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
@@ -221,6 +221,8 @@ describe("CLI quickstart integration", () => {
           resolvedProvider: "openai",
           providerMismatchWarning:
             "Configured provider 'anthropic' differs from detected env auth providers: openai",
+          conflictSummary:
+            "configured provider anthropic, detected env auth openai, resolved provider openai",
           resolvedModelEnvExample: "export OPENAI_MODEL=gpt-5.4",
         }),
         recommendations: expect.arrayContaining([
@@ -324,6 +326,9 @@ describe("CLI quickstart integration", () => {
     expect(stdout).toContain("Resolved provider model env example: export OPENAI_MODEL=gpt-5.4");
     expect(stderr).toContain(
       "Configured provider 'anthropic' differs from detected env auth providers: openai"
+    );
+    expect(stderr).toContain(
+      "Conflict summary: configured provider anthropic, detected env auth openai, resolved provider openai"
     );
   });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -57,6 +57,7 @@ interface DoctorAuthDiagnostics extends ProviderSetupExamples {
   resolvedModelRecommendationReason: string | null;
   detectedProviders: string[];
   providerMismatchWarning: string | null;
+  conflictSummary: string | null;
   setupGuide: string;
 }
 
@@ -487,6 +488,22 @@ function buildRecommendedProviderHint(
   };
 }
 
+function buildConflictSummary(
+  configuredProvider: string | null,
+  detectedProviders: string[],
+  resolvedProvider: string | null
+): string | null {
+  if (
+    !configuredProvider ||
+    detectedProviders.length === 0 ||
+    detectedProviders.includes(configuredProvider)
+  ) {
+    return null;
+  }
+
+  return `configured provider ${configuredProvider}, detected env auth ${detectedProviders.join(", ")}, resolved provider ${resolvedProvider ?? "none"}`;
+}
+
 function buildAuthDiagnostics(
   providerHint: DoctorProviderHint,
   summary: { provider: string | null }
@@ -502,6 +519,11 @@ function buildAuthDiagnostics(
     !detectedProviders.includes(providerHint.configuredProvider)
       ? `Configured provider '${providerHint.configuredProvider}' differs from detected env auth providers: ${detectedProviders.join(", ")}`
       : null;
+  const conflictSummary = buildConflictSummary(
+    providerHint.configuredProvider,
+    detectedProviders,
+    summary.provider
+  );
 
   return {
     configuredProvider: providerHint.configuredProvider,
@@ -517,6 +539,7 @@ function buildAuthDiagnostics(
     resolvedModelRecommendationReason: resolvedSetupExamples.modelRecommendationReason,
     detectedProviders,
     providerMismatchWarning,
+    conflictSummary,
     setupGuide: AUTH_SETUP_GUIDE,
     ...setupExamples,
   };
@@ -847,6 +870,9 @@ function buildDoctorOutputSections(
   const warnings = [...summary.warnings];
   if (authDiagnostics.providerMismatchWarning) {
     warnings.push(authDiagnostics.providerMismatchWarning);
+  }
+  if (authDiagnostics.conflictSummary) {
+    warnings.push(`Conflict summary: ${authDiagnostics.conflictSummary}`);
   }
 
   return {


### PR DESCRIPTION
## Summary
- add a one-line conflict summary for doctor provider/env mismatches
- expose the summary in JSON auth diagnostics
- surface the summary in text mode warnings for faster scanning
- extend doctor and quickstart e2e coverage for conflict summary output

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/doctor.test.ts src/commands/__tests__/quickstart-e2e.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- manual smoke: doctor with anthropic config + OPENAI_API_KEY env mismatch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved diagnostics in the doctor command to detect and clearly report conflicts between configured and detected authentication providers. Users now receive a conflict summary message indicating the configured provider, detected environment authentication, and the resolved provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->