### PR TITLE
feat(cli): tighten doctor mismatch copy

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -479,15 +479,13 @@ describe("doctor command", () => {
           auth: expect.objectContaining({
             providerMismatchWarning:
               "Configured provider 'anthropic' differs from detected env auth providers: openai",
-            conflictSummary:
-              "configured provider anthropic, detected env auth openai, resolved provider none",
+            conflictSummary: "config anthropic · env openai · resolved none",
           }),
           recommendations: expect.arrayContaining([
             "Detected env auth does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to one of: openai",
-            "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL",
-            expect.stringContaining(
-              "packages/cli/.obora/config.yaml and set defaults.provider: openai"
-            ),
+            "Shell fix: unset OPENAI_API_KEY OPENAI_MODEL",
+            expect.stringContaining("Config fix: edit "),
+            expect.stringContaining("packages/cli/.obora/config.yaml -> defaults.provider: openai"),
           ]),
         })
       );
@@ -507,7 +505,7 @@ describe("doctor command", () => {
         "Configured provider 'anthropic' differs from detected env auth providers: openai"
       );
       expect(formatter.warn).toHaveBeenCalledWith(
-        "Conflict summary: configured provider anthropic, detected env auth openai, resolved provider none"
+        "Conflict: config anthropic · env openai · resolved none"
       );
     });
 
@@ -542,16 +540,15 @@ describe("doctor command", () => {
             resolvedModelEnvExample: "export OPENAI_MODEL=gpt-5.4",
             resolvedModelConfigExample: "providers:\n  openai:\n    defaultModel: gpt-5.4",
             resolvedModelRecommendationReason: "pi-ai catalog latest GPT base model for openai",
-            conflictSummary:
-              "configured provider anthropic, detected env auth openai, resolved provider openai",
+            conflictSummary: "config anthropic · env openai · resolved openai",
           }),
           recommendations: expect.arrayContaining([
             "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
-            "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL",
-            "Switch config default provider: edit .obora/config.yaml and set defaults.provider: openai",
-            "Resolved provider model config example: providers:\n  openai:\n    defaultModel: gpt-5.4",
-            "Resolved provider model env example: export OPENAI_MODEL=gpt-5.4",
-            "Resolved provider model recommendation basis: pi-ai catalog latest GPT base model for openai",
+            "Shell fix: unset OPENAI_API_KEY OPENAI_MODEL",
+            "Config fix: edit .obora/config.yaml -> defaults.provider: openai",
+            "Resolved model config: providers:\n  openai:\n    defaultModel: gpt-5.4",
+            "Resolved model env: export OPENAI_MODEL=gpt-5.4",
+            "Resolved model basis: pi-ai catalog latest GPT base model for openai",
           ]),
         })
       );
@@ -660,7 +657,7 @@ describe("doctor command", () => {
       expect(formatter.step).toHaveBeenCalledWith("Configured default provider: anthropic");
       expect(formatter.step).toHaveBeenCalledWith("Recommended auth: export ANTHROPIC_API_KEY=***");
       expect(formatter.step).toHaveBeenCalledWith(
-        "Provider model recommendation basis: pi-ai catalog latest stable base Claude model for anthropic"
+        "Model basis: pi-ai catalog latest stable base Claude model for anthropic"
       );
     });
 
@@ -704,10 +701,10 @@ describe("doctor command", () => {
       await runDoctor({});
 
       expect(formatter.step).toHaveBeenCalledWith(
-        "Resolved provider model env example: export OPENAI_MODEL=gpt-5.4"
+        "Resolved model env: export OPENAI_MODEL=gpt-5.4"
       );
       expect(formatter.step).toHaveBeenCalledWith(
-        "Resolved provider model recommendation basis: pi-ai catalog latest GPT base model for openai"
+        "Resolved model basis: pi-ai catalog latest GPT base model for openai"
       );
     });
 

--- a/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
+++ b/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
@@ -221,17 +221,15 @@ describe("CLI quickstart integration", () => {
           resolvedProvider: "openai",
           providerMismatchWarning:
             "Configured provider 'anthropic' differs from detected env auth providers: openai",
-          conflictSummary:
-            "configured provider anthropic, detected env auth openai, resolved provider openai",
+          conflictSummary: "config anthropic · env openai · resolved openai",
           resolvedModelEnvExample: "export OPENAI_MODEL=gpt-5.4",
         }),
         recommendations: expect.arrayContaining([
           "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
-          "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL",
-          expect.stringContaining(
-            "contract-demo/.obora/config.yaml and set defaults.provider: openai"
-          ),
-          "Resolved provider model env example: export OPENAI_MODEL=gpt-5.4",
+          "Shell fix: unset OPENAI_API_KEY OPENAI_MODEL",
+          expect.stringContaining("Config fix: edit "),
+          expect.stringContaining("contract-demo/.obora/config.yaml -> defaults.provider: openai"),
+          "Resolved model env: export OPENAI_MODEL=gpt-5.4",
         ]),
       })
     );
@@ -317,19 +315,14 @@ describe("CLI quickstart integration", () => {
     expect(stdout).toContain("Resolution");
     expect(stdout).toContain("Configured provider: anthropic");
     expect(stdout).toContain("Resolved provider: openai");
-    expect(stdout).toContain(
-      "Use configured provider in this shell: unset OPENAI_API_KEY OPENAI_MODEL"
-    );
-    expect(stdout).toContain(
-      "doctor-stdout-demo/.obora/config.yaml and set defaults.provider: openai"
-    );
-    expect(stdout).toContain("Resolved provider model env example: export OPENAI_MODEL=gpt-5.4");
+    expect(stdout).toContain("Shell fix: unset OPENAI_API_KEY OPENAI_MODEL");
+    expect(stdout).toContain("Config fix: edit ");
+    expect(stdout).toContain("doctor-stdout-demo/.obora/config.yaml -> defaults.provider: openai");
+    expect(stdout).toContain("Resolved model env: export OPENAI_MODEL=gpt-5.4");
     expect(stderr).toContain(
       "Configured provider 'anthropic' differs from detected env auth providers: openai"
     );
-    expect(stderr).toContain(
-      "Conflict summary: configured provider anthropic, detected env auth openai, resolved provider openai"
-    );
+    expect(stderr).toContain("Conflict: config anthropic · env openai · resolved openai");
   });
 
   it("prints configured and resolved model context in doctor stdout", async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -501,7 +501,7 @@ function buildConflictSummary(
     return null;
   }
 
-  return `configured provider ${configuredProvider}, detected env auth ${detectedProviders.join(", ")}, resolved provider ${resolvedProvider ?? "none"}`;
+  return `config ${configuredProvider} · env ${detectedProviders.join(", ")} · resolved ${resolvedProvider ?? "none"}`;
 }
 
 function buildAuthDiagnostics(
@@ -610,7 +610,7 @@ function buildConfiguredProviderHints(providerHint: DoctorProviderHint): string[
     `Configured default provider: ${providerHint.recommendedProvider}`,
     `Recommended auth: export ${providerHint.recommendedAuthEnvKey}=***`,
     ...(setupExamples.modelRecommendationReason
-      ? [`Provider model recommendation basis: ${setupExamples.modelRecommendationReason}`]
+      ? [`Model basis: ${setupExamples.modelRecommendationReason}`]
       : []),
   ];
 }
@@ -638,14 +638,12 @@ function buildDetectedProviderMismatchRecommendations(
   });
 
   if (envKeysToUnset.length > 0) {
-    recommendations.push(
-      `Use configured provider in this shell: unset ${Array.from(new Set(envKeysToUnset)).join(" ")}`
-    );
+    recommendations.push(`Shell fix: unset ${Array.from(new Set(envKeysToUnset)).join(" ")}`);
   }
 
   if (authDiagnostics.detectedProviders.length === 1) {
     recommendations.push(
-      `Switch config default provider: edit ${checks.projectConfigPath} and set defaults.provider: ${authDiagnostics.detectedProviders[0]}`
+      `Config fix: edit ${checks.projectConfigPath} -> defaults.provider: ${authDiagnostics.detectedProviders[0]}`
     );
   }
 
@@ -678,14 +676,12 @@ function buildResolvedProviderMismatchRecommendations(
     authDiagnostics.resolvedModelEnvKey,
   ].filter((key): key is string => Boolean(key));
   if (envKeysToUnset.length > 0) {
-    recommendations.push(
-      `Use configured provider in this shell: unset ${Array.from(new Set(envKeysToUnset)).join(" ")}`
-    );
+    recommendations.push(`Shell fix: unset ${Array.from(new Set(envKeysToUnset)).join(" ")}`);
   }
 
   if (isConfigFilePath(summary.nextPlaceToEdit)) {
     recommendations.push(
-      `Switch config default provider: edit ${summary.nextPlaceToEdit} and set defaults.provider: ${summary.provider}`
+      `Config fix: edit ${summary.nextPlaceToEdit} -> defaults.provider: ${summary.provider}`
     );
   }
 
@@ -717,15 +713,9 @@ function buildProviderSpecificGuidance(
     const modelRecommendationReason = useResolvedExamples
       ? authDiagnostics.resolvedModelRecommendationReason
       : authDiagnostics.modelRecommendationReason;
-    const modelConfigPrefix = useResolvedExamples
-      ? "Resolved provider model config example"
-      : "Provider model config example";
-    const modelEnvPrefix = useResolvedExamples
-      ? "Resolved provider model env example"
-      : "Provider model env example";
-    const modelReasonPrefix = useResolvedExamples
-      ? "Resolved provider model recommendation basis"
-      : "Provider model recommendation basis";
+    const modelConfigPrefix = useResolvedExamples ? "Resolved model config" : "Model config";
+    const modelEnvPrefix = useResolvedExamples ? "Resolved model env" : "Model env";
+    const modelReasonPrefix = useResolvedExamples ? "Resolved model basis" : "Model basis";
 
     if (modelConfigExample) {
       guidance.push(`${modelConfigPrefix}: ${modelConfigExample}`);
@@ -872,7 +862,7 @@ function buildDoctorOutputSections(
     warnings.push(authDiagnostics.providerMismatchWarning);
   }
   if (authDiagnostics.conflictSummary) {
-    warnings.push(`Conflict summary: ${authDiagnostics.conflictSummary}`);
+    warnings.push(`Conflict: ${authDiagnostics.conflictSummary}`);
   }
 
   return {


### PR DESCRIPTION
## Summary
- shorten doctor conflict and fix wording for faster scanning
- normalize model helper labels to concise forms like model env/model basis
- update doctor and quickstart e2e coverage to lock the tightened wording

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/doctor.test.ts src/commands/__tests__/quickstart-e2e.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- manual smoke: doctor with anthropic config + OPENAI_API_KEY env mismatch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined doctor command output with condensed labels and consistent separator formatting for improved readability of provider conflict summaries and configuration recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->