### PR TITLE
feat(cli): prioritize relevant model matches

### DIFF
--- a/packages/cli/src/commands/__tests__/models.test.ts
+++ b/packages/cli/src/commands/__tests__/models.test.ts
@@ -44,6 +44,16 @@ import { createModelsCommand, runModels } from "../models.js";
 describe("models command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listPiAIProviders).mockReturnValue(["openai", "anthropic"]);
+    vi.mocked(listPiAIModels).mockImplementation((provider: string) => {
+      if (provider === "openai") {
+        return ["gpt-4o-mini", "gpt-4o", "gpt-5", "gpt-5.4"];
+      }
+      if (provider === "anthropic") {
+        return ["claude-3-7-sonnet-20250219", "claude-opus-4-6"];
+      }
+      throw new Error(`Unsupported provider: ${provider}`);
+    });
   });
 
   it("creates models command with correct name", () => {
@@ -86,6 +96,83 @@ describe("models command", () => {
     expect(formatter.step).toHaveBeenCalledWith("Match count: 2");
     expect(formatter.step).toHaveBeenCalledWith("anthropic: claude-3-7-sonnet-20250219");
     expect(formatter.step).toHaveBeenCalledWith("anthropic: claude-opus-4-6");
+  });
+
+  it("ranks global matches by relevance so exact refs appear before longer variants", async () => {
+    vi.mocked(listPiAIProviders).mockReturnValue(["openrouter"]);
+    vi.mocked(listPiAIModels).mockImplementation((provider: string) => {
+      if (provider === "openrouter") {
+        return ["openai/gpt-5.4-mini", "openai/gpt-5.4", "openai/gpt-5.4-pro"];
+      }
+      throw new Error(`Unsupported provider: ${provider}`);
+    });
+
+    await runModels("gpt-5.4", undefined, { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      query: "gpt-5.4",
+      count: 3,
+      matches: [
+        { provider: "openrouter", model: "openai/gpt-5.4" },
+        { provider: "openrouter", model: "openai/gpt-5.4-mini" },
+        { provider: "openrouter", model: "openai/gpt-5.4-pro" },
+      ],
+    });
+  });
+
+  it("keeps equally relevant global matches in provider catalog priority order", async () => {
+    vi.mocked(listPiAIProviders).mockReturnValue(["openai", "openrouter", "github-copilot"]);
+    vi.mocked(listPiAIModels).mockImplementation((provider: string) => {
+      if (provider === "openai") {
+        return ["gpt-5.4"];
+      }
+      if (provider === "openrouter") {
+        return ["openai/gpt-5.4"];
+      }
+      if (provider === "github-copilot") {
+        return ["gpt-5.4"];
+      }
+      throw new Error(`Unsupported provider: ${provider}`);
+    });
+
+    await runModels("gpt-5.4", undefined, { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      query: "gpt-5.4",
+      count: 3,
+      matches: [
+        { provider: "openai", model: "gpt-5.4" },
+        { provider: "github-copilot", model: "gpt-5.4" },
+        { provider: "openrouter", model: "openai/gpt-5.4" },
+      ],
+    });
+  });
+
+  it("keeps provider catalog priority even when equally relevant variants differ by name", async () => {
+    vi.mocked(listPiAIProviders).mockReturnValue(["openai", "github-copilot"]);
+    vi.mocked(listPiAIModels).mockImplementation((provider: string) => {
+      if (provider === "openai") {
+        return ["gpt-5.4-pro"];
+      }
+      if (provider === "github-copilot") {
+        return ["gpt-5.4-mini"];
+      }
+      throw new Error(`Unsupported provider: ${provider}`);
+    });
+
+    await runModels("gpt-5.4", undefined, { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      query: "gpt-5.4",
+      count: 2,
+      matches: [
+        { provider: "openai", model: "gpt-5.4-pro" },
+        { provider: "github-copilot", model: "gpt-5.4-mini" },
+      ],
+    });
   });
 
   it("prints a helpful hint when global search returns no matches in text mode", async () => {
@@ -149,6 +236,28 @@ describe("models command", () => {
       query: "gpt-5",
       count: 2,
       models: ["gpt-5", "gpt-5.4"],
+    });
+  });
+
+  it("ranks provider matches by relevance so exact refs appear before longer variants", async () => {
+    vi.mocked(listPiAIModels).mockImplementation((provider: string) => {
+      if (provider === "openai") {
+        return ["gpt-5.4-mini", "gpt-5.4", "gpt-5.4-pro"];
+      }
+      if (provider === "anthropic") {
+        return ["claude-3-7-sonnet-20250219", "claude-opus-4-6"];
+      }
+      throw new Error(`Unsupported provider: ${provider}`);
+    });
+
+    await runModels("openai", "gpt-5.4", { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      provider: "openai",
+      query: "gpt-5.4",
+      count: 3,
+      models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-pro"],
     });
   });
 

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -32,22 +32,109 @@ function buildProviderNoMatchHint(query: string, providers: string[]): string {
   return `No models matched this provider filter. Check the query spelling or run \`obora models ${suggestedQuery}\`.`;
 }
 
+function naturalCompare(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+}
+
+function getModelSearchFields(model: string): { full: string; tail: string } {
+  const full = model.toLowerCase();
+  const slashIndex = full.lastIndexOf("/");
+  const tail = slashIndex >= 0 ? full.slice(slashIndex + 1) : full;
+  return { full, tail };
+}
+
+function getModelMatchRank(model: string, query: string): number {
+  const normalizedQuery = query.toLowerCase();
+  const { full, tail } = getModelSearchFields(model);
+
+  if (full === normalizedQuery) {
+    return 0;
+  }
+  if (tail === normalizedQuery) {
+    return 1;
+  }
+  if (full.startsWith(normalizedQuery)) {
+    return 2;
+  }
+  if (tail.startsWith(normalizedQuery)) {
+    return 3;
+  }
+  if (full.includes(normalizedQuery)) {
+    return 4;
+  }
+  if (tail.includes(normalizedQuery)) {
+    return 5;
+  }
+  return 6;
+}
+
+function compareModelsByRelevance(left: string, right: string, query: string): number {
+  const rankDiff = getModelMatchRank(left, query) - getModelMatchRank(right, query);
+  if (rankDiff !== 0) {
+    return rankDiff;
+  }
+
+  const leftFields = getModelSearchFields(left);
+  const rightFields = getModelSearchFields(right);
+  const tailDiff = naturalCompare(leftFields.tail, rightFields.tail);
+  if (tailDiff !== 0) {
+    return tailDiff;
+  }
+
+  const lengthDiff = leftFields.full.length - rightFields.full.length;
+  if (lengthDiff !== 0) {
+    return lengthDiff;
+  }
+
+  return naturalCompare(leftFields.full, rightFields.full);
+}
+
 function filterModels(models: string[], query?: string): string[] {
   if (!query) {
     return models;
   }
 
   const normalizedQuery = query.toLowerCase();
-  return models.filter((model) => model.toLowerCase().includes(normalizedQuery));
+  return models
+    .filter((model) => model.toLowerCase().includes(normalizedQuery))
+    .sort((left, right) => compareModelsByRelevance(left, right, query));
 }
 
 function buildGlobalMatches(providers: string[], query: string): GlobalModelMatch[] {
-  return providers.flatMap((provider) =>
-    filterModels(listPiAIModels(provider), query).map((model) => ({
-      provider,
-      model,
-    }))
-  );
+  const providerPriority = new Map(providers.map((provider, index) => [provider, index]));
+
+  return providers
+    .flatMap((provider) =>
+      filterModels(listPiAIModels(provider), query).map((model) => ({
+        provider,
+        model,
+      }))
+    )
+    .sort((left, right) => {
+      const rankDiff = getModelMatchRank(left.model, query) - getModelMatchRank(right.model, query);
+      if (rankDiff !== 0) {
+        return rankDiff;
+      }
+
+      const priorityDiff =
+        (providerPriority.get(left.provider) ?? Number.MAX_SAFE_INTEGER) -
+        (providerPriority.get(right.provider) ?? Number.MAX_SAFE_INTEGER);
+      if (priorityDiff !== 0) {
+        return priorityDiff;
+      }
+
+      const modelDiff = compareModelsByRelevance(left.model, right.model, query);
+      if (modelDiff !== 0) {
+        return modelDiff;
+      }
+
+      const providerDiff = naturalCompare(left.provider, right.provider);
+      if (providerDiff !== 0) {
+        return providerDiff;
+      }
+
+      return naturalCompare(left.model, right.model);
+    });
 }
 
 function printGlobalMatches(


### PR DESCRIPTION
## Summary
- rank filtered model results by match relevance so exact refs appear before longer variants
- keep global result ties in provider catalog priority order
- add regression tests for exact-match promotion and provider-priority ordering

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/models.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- node packages/cli/bin/obora.js --json models gpt-5.4
- node packages/cli/bin/obora.js --json models openai gpt-5.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced model search result ranking to prioritize exact and relevant matches over partial matches
  * Exact query matches now appear before longer or variant matches
  * Results sorted by relevance and provider priority for consistent, predictable ordering across searches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->