### PR TITLE
feat(cli): add doctor json overview

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -162,6 +162,37 @@ describe("doctor command", () => {
               command: "obora doctor",
             }),
           ]),
+          overview: expect.objectContaining({
+            status: "needs_config",
+            fallbackStub: true,
+            configuredProvider: null,
+            resolvedProvider: null,
+            resolvedModel: null,
+          }),
+          diagnostics: expect.objectContaining({
+            checks: expect.objectContaining({
+              projectConfig: false,
+              globalConfig: false,
+            }),
+            auth: expect.objectContaining({
+              detectedProviders: [],
+            }),
+            resolution: expect.objectContaining({
+              fallbackStub: true,
+            }),
+          }),
+          guidance: expect.objectContaining({
+            recommendations: expect.arrayContaining([
+              expect.stringContaining("obora init --quickstart"),
+              expect.stringContaining("obora doctor"),
+            ]),
+            actions: expect.arrayContaining([
+              expect.objectContaining({
+                kind: "run",
+                command: expect.stringContaining("obora init --quickstart"),
+              }),
+            ]),
+          }),
           resolution: expect.objectContaining({
             fallbackStub: true,
           }),
@@ -578,6 +609,32 @@ describe("doctor command", () => {
               value: "openai",
             }),
           ]),
+          overview: expect.objectContaining({
+            status: "needs_config",
+            configuredProvider: "anthropic",
+            resolvedProvider: "openai",
+            conflictSummary: "config anthropic · env openai · resolved openai",
+          }),
+          diagnostics: expect.objectContaining({
+            auth: expect.objectContaining({
+              resolvedProvider: "openai",
+              conflictSummary: "config anthropic · env openai · resolved openai",
+            }),
+            config: expect.objectContaining({
+              nextPlaceToEdit: ".obora/config.yaml",
+            }),
+          }),
+          guidance: expect.objectContaining({
+            actions: expect.arrayContaining([
+              expect.objectContaining({
+                kind: "shell",
+                shellCommand: "unset OPENAI_API_KEY OPENAI_MODEL",
+              }),
+            ]),
+            recommendations: expect.arrayContaining([
+              "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
+            ]),
+          }),
         })
       );
     });

--- a/packages/cli/src/commands/doctor-shared.ts
+++ b/packages/cli/src/commands/doctor-shared.ts
@@ -113,6 +113,40 @@ export interface DoctorOutputSections {
   };
 }
 
+export interface DoctorOverview {
+  status: "ready" | "needs_config" | "stub_mode";
+  message: string;
+  configuredProvider: string | null;
+  configuredModel: string | null;
+  resolvedProvider: string | null;
+  resolvedModel: string | null;
+  fallbackStub: boolean;
+  conflictSummary: string | null;
+  nextPlaceToEdit: string;
+}
+
+export interface DoctorDiagnosticsBundle {
+  checks: DoctorChecks;
+  auth: DoctorAuthDiagnostics;
+  config: DoctorConfigDiagnostics;
+  resolution: {
+    provider: string | null;
+    model: string | null;
+    authSource: string;
+    configSource: string;
+    modelSource: string;
+    chosenByPrecedence: string;
+    nextPlaceToEdit: string;
+    fallbackStub: boolean;
+    warnings: string[];
+  };
+}
+
+export interface DoctorGuidance {
+  recommendations: string[];
+  actions: DoctorAction[];
+}
+
 export const AUTH_ENV_EXAMPLES = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ZAI_API_KEY"] as const;
 
 export const AUTH_SETUP_GUIDE = "docs/tutorials/06-llm-config-auth-quickstart.md";
@@ -1070,6 +1104,64 @@ export function buildDoctorOutputSections(
       heading: "Recommended next actions",
       items: recommendations,
     },
+  };
+}
+
+export function buildDoctorOverview(
+  status: { status: "ready" | "needs_config" | "stub_mode"; message: string },
+  loadedConfig: OboraConfig | undefined,
+  summary: {
+    provider: string | null;
+    model: string | null;
+    nextPlaceToEdit: string;
+    fallbackStub: boolean;
+  },
+  authDiagnostics: DoctorAuthDiagnostics
+): DoctorOverview {
+  return {
+    status: status.status,
+    message: status.message,
+    configuredProvider: authDiagnostics.configuredProvider,
+    configuredModel: loadedConfig?.defaults?.model ?? null,
+    resolvedProvider: summary.provider,
+    resolvedModel: summary.model,
+    fallbackStub: summary.fallbackStub,
+    conflictSummary: authDiagnostics.conflictSummary,
+    nextPlaceToEdit: summary.nextPlaceToEdit,
+  };
+}
+
+export function buildDoctorDiagnosticsBundle(
+  checks: DoctorChecks,
+  authDiagnostics: DoctorAuthDiagnostics,
+  configDiagnostics: DoctorConfigDiagnostics,
+  summary: {
+    provider: string | null;
+    model: string | null;
+    authSource: string;
+    configSource: string;
+    modelSource: string;
+    chosenByPrecedence: string;
+    nextPlaceToEdit: string;
+    fallbackStub: boolean;
+    warnings: string[];
+  }
+): DoctorDiagnosticsBundle {
+  return {
+    checks,
+    auth: authDiagnostics,
+    config: configDiagnostics,
+    resolution: summary,
+  };
+}
+
+export function buildDoctorGuidance(
+  recommendations: string[],
+  actions: DoctorAction[]
+): DoctorGuidance {
+  return {
+    recommendations,
+    actions,
   };
 }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -15,7 +15,10 @@ import {
   buildConfigDiagnostics,
   buildDoctorActions,
   buildDoctorChecks,
+  buildDoctorDiagnosticsBundle,
+  buildDoctorGuidance,
   buildDoctorOutputSections,
+  buildDoctorOverview,
   buildDoctorRecommendations,
   buildDoctorStatus,
   buildRecommendedProviderHint,
@@ -49,6 +52,14 @@ export async function runDoctor(options: DoctorOptions): Promise<void> {
     authDiagnostics,
     recommendations
   );
+  const overview = buildDoctorOverview(status, loadedConfig, summary, authDiagnostics);
+  const diagnostics = buildDoctorDiagnosticsBundle(
+    checks,
+    authDiagnostics,
+    configDiagnostics,
+    summary
+  );
+  const guidance = buildDoctorGuidance(recommendations, actions);
 
   if (options.json) {
     formatter.json({
@@ -62,6 +73,9 @@ export async function runDoctor(options: DoctorOptions): Promise<void> {
       status,
       recommendations,
       actions,
+      overview,
+      diagnostics,
+      guidance,
       resolution: summary,
       auth: authDiagnostics,
       config: configDiagnostics,


### PR DESCRIPTION
## Summary
- add nested `overview`, `diagnostics`, and `guidance` bundles to `doctor --json`
- keep existing top-level fields for backward compatibility
- add regression coverage for ready/setup/mismatch contract shapes

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/doctor.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- node packages/cli/bin/obora.js --json doctor
- OPENAI_API_KEY=test-key node packages/cli/bin/obora.js --json doctor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced doctor command with improved JSON output structure providing overview status, detailed diagnostics bundle, and actionable guidance for configuration troubleshooting.

* **Tests**
  * Expanded doctor command tests to validate new overview, diagnostics, and guidance sections in JSON output, including provider mismatch and configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->