### PR TITLE
feat(cli): tighten doctor provider guidance

### DIFF
--- a/packages/cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/cli/src/commands/__tests__/doctor.test.ts
@@ -270,6 +270,13 @@ describe("doctor command", () => {
         expect.objectContaining({
           recommendedProvider: "anthropic",
           recommendedAuthEnvKey: "ANTHROPIC_API_KEY",
+          actions: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "env",
+              envKey: "ANTHROPIC_API_KEY",
+              shellCommand: "export ANTHROPIC_API_KEY=***",
+            }),
+          ]),
         })
       );
     });
@@ -587,9 +594,6 @@ describe("doctor command", () => {
             "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
             "Shell fix: unset OPENAI_API_KEY OPENAI_MODEL",
             "Config fix: edit .obora/config.yaml -> defaults.provider: openai",
-            "Resolved model config: providers:\n  openai:\n    defaultModel: gpt-5.4",
-            "Resolved model env: export OPENAI_MODEL=gpt-5.4",
-            "Resolved model basis: pi-ai catalog latest GPT base model for openai",
           ]),
           actions: expect.arrayContaining([
             expect.objectContaining({
@@ -609,8 +613,13 @@ describe("doctor command", () => {
               value: "openai",
             }),
           ]),
+          status: expect.objectContaining({
+            status: "needs_config",
+            message: "Needs provider alignment: configured anthropic but resolved openai",
+          }),
           overview: expect.objectContaining({
             status: "needs_config",
+            message: "Needs provider alignment: configured anthropic but resolved openai",
             configuredProvider: "anthropic",
             resolvedProvider: "openai",
             conflictSummary: "config anthropic · env openai · resolved openai",
@@ -636,6 +645,33 @@ describe("doctor command", () => {
             ]),
           }),
         })
+      );
+
+      const payload = vi.mocked(formatter.json).mock.calls[0]?.[0];
+      expect(payload.actions).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "providers.openai.defaultModel",
+            value: "gpt-5.4",
+          }),
+          expect.objectContaining({
+            envKey: "OPENAI_MODEL",
+            shellCommand: "export OPENAI_MODEL=gpt-5.4",
+          }),
+          expect.objectContaining({
+            envKey: "OPENAI_MODEL",
+            shellCommand: "export OPENAI_MODEL=***",
+          }),
+        ])
+      );
+      expect(payload.recommendations).not.toContain(
+        "Set a default model in .obora/config.yaml or export OPENAI_MODEL=***"
+      );
+      expect(payload.recommendations).not.toContain(
+        "Resolved model config: providers:\n  openai:\n    defaultModel: gpt-5.4"
+      );
+      expect(payload.recommendations).not.toContain(
+        "Resolved model env: export OPENAI_MODEL=gpt-5.4"
       );
     });
 
@@ -769,6 +805,44 @@ describe("doctor command", () => {
       expect(formatter.step).toHaveBeenCalledWith("Run your workflow: obora run judge.yaml");
     });
 
+    it("should prioritize provider alignment over ready status when configured and resolved providers differ", async () => {
+      vi.mocked(loadConfig).mockResolvedValue({
+        defaults: {
+          provider: "anthropic",
+        },
+      });
+      vi.mocked(buildResolutionSummary).mockReturnValue({
+        provider: "openai",
+        model: "gpt-5.4",
+        authSource: "env(OPENAI_API_KEY)",
+        configSource: ".obora/config.yaml",
+        modelSource: "env(OPENAI_MODEL)",
+        chosenByPrecedence: "env > config",
+        nextPlaceToEdit: ".obora/config.yaml",
+        fallbackStub: false,
+        warnings: [],
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await runDoctor({ json: true });
+
+      expect(formatter.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: expect.objectContaining({
+            status: "needs_config",
+            message: "Needs provider alignment: configured anthropic but resolved openai",
+          }),
+          overview: expect.objectContaining({
+            status: "needs_config",
+            message: "Needs provider alignment: configured anthropic but resolved openai",
+          }),
+          recommendations: expect.arrayContaining([
+            "Resolved provider does not match configured provider. Either export ANTHROPIC_API_KEY=*** or switch defaults.provider to openai",
+          ]),
+        })
+      );
+    });
+
     it("should show resolved model recommendation basis in env-only missing-model text output", async () => {
       process.env.OPENAI_API_KEY = "***";
       vi.mocked(buildResolutionSummary).mockReturnValue({
@@ -794,7 +868,7 @@ describe("doctor command", () => {
     });
 
     it("should diagnose missing model when auth exists but model is unresolved", async () => {
-      process.env.OPENAI_API_KEY = "test-key";
+      process.env.OPENAI_API_KEY = "***";
       vi.mocked(buildResolutionSummary).mockReturnValue({
         provider: "openai",
         model: null,
@@ -817,10 +891,49 @@ describe("doctor command", () => {
             message: "Needs model: provider auth detected but no model is resolved",
           }),
           recommendations: expect.arrayContaining([
-            "Set a default model in .obora/config.yaml or export OPENAI_MODEL=***",
+            "Config fix: edit .obora/config.yaml -> providers.openai.defaultModel: gpt-5.4",
+            "Shell fix: export OPENAI_MODEL=gpt-5.4",
+          ]),
+          actions: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "config",
+              path: ".obora/config.yaml",
+              key: "providers.openai.defaultModel",
+              value: "gpt-5.4",
+            }),
+            expect.objectContaining({
+              kind: "env",
+              envKey: "OPENAI_MODEL",
+              shellCommand: "export OPENAI_MODEL=gpt-5.4",
+            }),
           ]),
         })
       );
+    });
+
+    it("should avoid placeholder model fixes when no catalog-backed default exists", async () => {
+      process.env.GROQ_API_KEY = "***";
+      vi.mocked(buildResolutionSummary).mockReturnValue({
+        provider: "groq",
+        model: null,
+        authSource: "env(GROQ_API_KEY)",
+        configSource: ".obora/config.yaml",
+        modelSource: "none",
+        chosenByPrecedence: "config > env",
+        nextPlaceToEdit: ".obora/config.yaml",
+        fallbackStub: false,
+        warnings: [],
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await runDoctor({ json: true });
+
+      const payload = vi.mocked(formatter.json).mock.calls[0]?.[0];
+      expect(payload.recommendations).toContain(
+        "Set a default model in .obora/config.yaml or export GROQ_MODEL=***"
+      );
+      expect(JSON.stringify(payload.actions)).not.toContain("your-model-name");
+      expect(JSON.stringify(payload.recommendations)).not.toContain("your-model-name");
     });
   });
 });

--- a/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
+++ b/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
@@ -216,6 +216,10 @@ describe("CLI quickstart integration", () => {
     const mismatchPayload = lastJsonCall();
     expect(mismatchPayload).toEqual(
       expect.objectContaining({
+        status: expect.objectContaining({
+          status: "needs_config",
+          message: "Needs provider alignment: configured anthropic but resolved openai",
+        }),
         auth: expect.objectContaining({
           configuredProvider: "anthropic",
           resolvedProvider: "openai",
@@ -229,7 +233,6 @@ describe("CLI quickstart integration", () => {
           "Shell fix: unset OPENAI_API_KEY OPENAI_MODEL",
           expect.stringContaining("Config fix: edit "),
           expect.stringContaining("contract-demo/.obora/config.yaml -> defaults.provider: openai"),
-          "Resolved model env: export OPENAI_MODEL=gpt-5.4",
         ]),
       })
     );
@@ -311,6 +314,7 @@ describe("CLI quickstart integration", () => {
     const stderr = errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
 
     expect(stdout).toContain("Status");
+    expect(stdout).toContain("Needs provider alignment: configured anthropic but resolved openai");
     expect(stdout).toContain("Configuration");
     expect(stdout).toContain("Resolution");
     expect(stdout).toContain("Configured provider: anthropic");
@@ -318,7 +322,6 @@ describe("CLI quickstart integration", () => {
     expect(stdout).toContain("Shell fix: unset OPENAI_API_KEY OPENAI_MODEL");
     expect(stdout).toContain("Config fix: edit ");
     expect(stdout).toContain("doctor-stdout-demo/.obora/config.yaml -> defaults.provider: openai");
-    expect(stdout).toContain("Resolved model env: export OPENAI_MODEL=gpt-5.4");
     expect(stderr).toContain(
       "Configured provider 'anthropic' differs from detected env auth providers: openai"
     );

--- a/packages/cli/src/commands/doctor-shared.ts
+++ b/packages/cli/src/commands/doctor-shared.ts
@@ -632,6 +632,15 @@ export function summarizeConfigChain(configDiagnostics: DoctorConfigDiagnostics)
   return labels.join(" -> ");
 }
 
+function extractExportValue(example: string | null): string | null {
+  if (!example) {
+    return null;
+  }
+
+  const match = /^export [A-Z0-9_]+=(.+)$/.exec(example.trim());
+  return match?.[1] ?? null;
+}
+
 export function buildAuthExampleHint(summary: { authSource: string }): string | null {
   if (summary.authSource !== "none") {
     return null;
@@ -839,32 +848,43 @@ export function buildProviderSpecificGuidance(
   }
 
   if (summary.provider && !summary.model) {
-    const useResolvedExamples =
-      authDiagnostics.resolvedProvider &&
-      (!authDiagnostics.configuredProvider ||
-        authDiagnostics.resolvedProvider !== authDiagnostics.configuredProvider);
+    const hasProviderMismatch =
+      Boolean(authDiagnostics.configuredProvider) &&
+      Boolean(authDiagnostics.resolvedProvider) &&
+      authDiagnostics.configuredProvider !== authDiagnostics.resolvedProvider;
 
-    const modelConfigExample = useResolvedExamples
-      ? authDiagnostics.resolvedModelConfigExample
-      : authDiagnostics.modelConfigExample;
-    const modelEnvExample = useResolvedExamples
-      ? authDiagnostics.resolvedModelEnvExample
-      : authDiagnostics.modelEnvExample;
-    const modelRecommendationReason = useResolvedExamples
-      ? authDiagnostics.resolvedModelRecommendationReason
-      : authDiagnostics.modelRecommendationReason;
-    const modelConfigPrefix = useResolvedExamples ? "Resolved model config" : "Model config";
-    const modelEnvPrefix = useResolvedExamples ? "Resolved model env" : "Model env";
-    const modelReasonPrefix = useResolvedExamples ? "Resolved model basis" : "Model basis";
+    if (!hasProviderMismatch) {
+      const useResolvedExamples =
+        authDiagnostics.resolvedProvider &&
+        (!authDiagnostics.configuredProvider ||
+          authDiagnostics.resolvedProvider !== authDiagnostics.configuredProvider);
 
-    if (modelConfigExample) {
-      guidance.push(`${modelConfigPrefix}: ${modelConfigExample}`);
-    }
-    if (modelEnvExample) {
-      guidance.push(`${modelEnvPrefix}: ${modelEnvExample}`);
-    }
-    if (modelRecommendationReason) {
-      guidance.push(`${modelReasonPrefix}: ${modelRecommendationReason}`);
+      const modelConfigExample = useResolvedExamples
+        ? authDiagnostics.resolvedModelConfigExample
+        : authDiagnostics.modelConfigExample;
+      const modelEnvExample = useResolvedExamples
+        ? authDiagnostics.resolvedModelEnvExample
+        : authDiagnostics.modelEnvExample;
+      const modelRecommendationReason = useResolvedExamples
+        ? authDiagnostics.resolvedModelRecommendationReason
+        : authDiagnostics.modelRecommendationReason;
+      const modelConfigPrefix = useResolvedExamples ? "Resolved model config" : "Model config";
+      const modelEnvPrefix = useResolvedExamples ? "Resolved model env" : "Model env";
+      const modelReasonPrefix = useResolvedExamples ? "Resolved model basis" : "Model basis";
+
+      const hasConcreteRecommendedModel =
+        extractExportValue(modelEnvExample) !== null &&
+        extractExportValue(modelEnvExample) !== "your-model-name";
+
+      if (modelConfigExample && hasConcreteRecommendedModel) {
+        guidance.push(`${modelConfigPrefix}: ${modelConfigExample}`);
+      }
+      if (modelEnvExample && hasConcreteRecommendedModel) {
+        guidance.push(`${modelEnvPrefix}: ${modelEnvExample}`);
+      }
+      if (modelRecommendationReason) {
+        guidance.push(`${modelReasonPrefix}: ${modelRecommendationReason}`);
+      }
     }
   }
 
@@ -884,12 +904,26 @@ export function buildDoctorChecks(): DoctorChecks {
   };
 }
 
-export function buildDoctorStatus(summary: {
-  provider: string | null;
-  model: string | null;
-  authSource: string;
-  fallbackStub: boolean;
-}): { status: "ready" | "needs_config" | "stub_mode"; message: string } {
+export function buildDoctorStatus(
+  summary: {
+    provider: string | null;
+    model: string | null;
+    authSource: string;
+    fallbackStub: boolean;
+  },
+  authDiagnostics?: { configuredProvider: string | null }
+): { status: "ready" | "needs_config" | "stub_mode"; message: string } {
+  if (
+    authDiagnostics?.configuredProvider &&
+    summary.provider &&
+    authDiagnostics.configuredProvider !== summary.provider
+  ) {
+    return {
+      status: "needs_config",
+      message: `Needs provider alignment: configured ${authDiagnostics.configuredProvider} but resolved ${summary.provider}`,
+    };
+  }
+
   if (!summary.fallbackStub && summary.provider && summary.model) {
     return {
       status: "ready",
@@ -957,9 +991,32 @@ export function buildDoctorRecommendations(
   recommendations.push(...buildProviderSpecificGuidance(summary, authDiagnostics));
 
   if (summary.provider && !summary.model) {
-    recommendations.push(
-      `Set a default model in .obora/config.yaml or export ${inferModelEnvKey(summary.provider)}=***`
-    );
+    const recommendedModelValue =
+      extractExportValue(authDiagnostics.resolvedModelEnvExample) ??
+      extractExportValue(authDiagnostics.modelEnvExample);
+    const hasConcreteRecommendedModel =
+      Boolean(recommendedModelValue) && recommendedModelValue !== "your-model-name";
+    const hasProviderMismatch =
+      Boolean(summary.provider) &&
+      Boolean(providerHint.configuredProvider) &&
+      summary.provider !== providerHint.configuredProvider;
+
+    if (!hasProviderMismatch) {
+      if (hasConcreteRecommendedModel) {
+        if (isConfigFilePath(summary.nextPlaceToEdit)) {
+          recommendations.push(
+            `Config fix: edit ${summary.nextPlaceToEdit} -> providers.${summary.provider}.defaultModel: ${recommendedModelValue}`
+          );
+        }
+        recommendations.push(
+          `Shell fix: export ${inferModelEnvKey(summary.provider)}=${recommendedModelValue}`
+        );
+      } else {
+        recommendations.push(
+          `Set a default model in .obora/config.yaml or export ${inferModelEnvKey(summary.provider)}=***`
+        );
+      }
+    }
   }
 
   if (summary.configSource === "none") {
@@ -1000,6 +1057,13 @@ export function buildDoctorActions(
   if (summary.authSource === "none") {
     pushDoctorAction(actions, { kind: "run", command: "obora doctor" });
     pushDoctorAction(actions, { kind: "doc", path: authDiagnostics.setupGuide });
+    if (providerHint.recommendedAuthEnvKey) {
+      pushDoctorAction(actions, {
+        kind: "env",
+        envKey: providerHint.recommendedAuthEnvKey,
+        shellCommand: `export ${providerHint.recommendedAuthEnvKey}=***`,
+      });
+    }
   }
 
   for (const action of buildDetectedProviderMismatchActions(
@@ -1019,11 +1083,40 @@ export function buildDoctorActions(
   }
 
   if (summary.provider && !summary.model) {
-    pushDoctorAction(actions, {
-      kind: "env",
-      envKey: inferModelEnvKey(summary.provider),
-      shellCommand: `export ${inferModelEnvKey(summary.provider)}=***`,
-    });
+    const recommendedModelValue =
+      extractExportValue(authDiagnostics.resolvedModelEnvExample) ??
+      extractExportValue(authDiagnostics.modelEnvExample);
+    const hasConcreteRecommendedModel =
+      Boolean(recommendedModelValue) && recommendedModelValue !== "your-model-name";
+    const hasProviderMismatch =
+      Boolean(summary.provider) &&
+      Boolean(providerHint.configuredProvider) &&
+      summary.provider !== providerHint.configuredProvider;
+
+    if (!hasProviderMismatch) {
+      if (hasConcreteRecommendedModel) {
+        if (isConfigFilePath(summary.nextPlaceToEdit)) {
+          pushDoctorAction(actions, {
+            kind: "config",
+            path: summary.nextPlaceToEdit,
+            key: `providers.${summary.provider}.defaultModel`,
+            value: recommendedModelValue,
+          });
+        }
+
+        pushDoctorAction(actions, {
+          kind: "env",
+          envKey: inferModelEnvKey(summary.provider),
+          shellCommand: `export ${inferModelEnvKey(summary.provider)}=${recommendedModelValue}`,
+        });
+      } else {
+        pushDoctorAction(actions, {
+          kind: "env",
+          envKey: inferModelEnvKey(summary.provider),
+          shellCommand: `export ${inferModelEnvKey(summary.provider)}=***`,
+        });
+      }
+    }
   }
 
   if (summary.fallbackStub) {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -32,9 +32,9 @@ export async function runDoctor(options: DoctorOptions): Promise<void> {
   const envLLM = detectLLMConfigFromEnv();
   const resolvedLLM = resolveLLMConfig(envLLM, loadedConfig);
   const summary = buildResolutionSummary({}, resolvedLLM, loadedConfig);
-  const status = buildDoctorStatus(summary);
   const providerHint = buildRecommendedProviderHint(summary, loadedConfig);
   const authDiagnostics = buildAuthDiagnostics(providerHint, summary);
+  const status = buildDoctorStatus(summary, authDiagnostics);
   const configDiagnostics = buildConfigDiagnostics(checks, summary);
   const recommendations = buildDoctorRecommendations(
     checks,


### PR DESCRIPTION
## Summary
- add direct provider-auth env actions when config selects a provider but auth is missing
- make missing-model fixes provider-specific only when a concrete recommended model exists
- prioritize provider-alignment status over ready/model-missing in mismatch scenarios and update doctor/quickstart coverage

## Test Plan
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/doctor.test.ts
- pnpm --filter @obora/cli exec vitest run src/commands/__tests__/doctor.test.ts src/commands/__tests__/quickstart-e2e.test.ts
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint
- OPENAI_API_KEY=test-key node packages/cli/bin/obora.js --json doctor
- OPENAI_API_KEY=test-key OPENAI_MODEL=gpt-5.4 node packages/cli/bin/obora.js --json doctor
- GROQ_API_KEY=test-key node packages/cli/bin/obora.js --json doctor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor command now detects and prioritizes provider alignment issues, providing actionable status messages.
  * Added provider-specific auth environment variable export recommendations.
  
* **Bug Fixes**
  * Improved diagnosis to suppress misleading model recommendations when configured and resolved providers differ.
  * Doctor command now provides concrete model configuration values instead of placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->