### PR TITLE
feat(cli): unify diagnostic guidance output

### DIFF
--- a/packages/cli/src/commands/__tests__/models.test.ts
+++ b/packages/cli/src/commands/__tests__/models.test.ts
@@ -70,6 +70,20 @@ describe("models command", () => {
         { provider: "openai", count: 4 },
         { provider: "anthropic", count: 2 },
       ],
+      overview: {
+        mode: "providers",
+        source: "pi-ai",
+        count: 2,
+      },
+      diagnostics: {
+        providers: [
+          { provider: "openai", count: 4 },
+          { provider: "anthropic", count: 2 },
+        ],
+      },
+      guidance: {
+        nextStep: "obora models <provider> [query]",
+      },
     });
   });
 
@@ -84,6 +98,21 @@ describe("models command", () => {
         { provider: "openai", model: "gpt-5" },
         { provider: "openai", model: "gpt-5.4" },
       ],
+      overview: {
+        mode: "global",
+        source: "pi-ai",
+        query: "gpt-5",
+        count: 2,
+      },
+      diagnostics: {
+        matches: [
+          { provider: "openai", model: "gpt-5" },
+          { provider: "openai", model: "gpt-5.4" },
+        ],
+      },
+      guidance: {
+        nextStep: "obora models openai gpt-5",
+      },
     });
   });
 
@@ -109,16 +138,18 @@ describe("models command", () => {
 
     await runModels("gpt-5.4", undefined, { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      query: "gpt-5.4",
-      count: 3,
-      matches: [
-        { provider: "openrouter", model: "openai/gpt-5.4" },
-        { provider: "openrouter", model: "openai/gpt-5.4-mini" },
-        { provider: "openrouter", model: "openai/gpt-5.4-pro" },
-      ],
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        query: "gpt-5.4",
+        count: 3,
+        matches: [
+          { provider: "openrouter", model: "openai/gpt-5.4" },
+          { provider: "openrouter", model: "openai/gpt-5.4-mini" },
+          { provider: "openrouter", model: "openai/gpt-5.4-pro" },
+        ],
+      })
+    );
   });
 
   it("keeps equally relevant global matches in provider catalog priority order", async () => {
@@ -138,16 +169,18 @@ describe("models command", () => {
 
     await runModels("gpt-5.4", undefined, { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      query: "gpt-5.4",
-      count: 3,
-      matches: [
-        { provider: "openai", model: "gpt-5.4" },
-        { provider: "github-copilot", model: "gpt-5.4" },
-        { provider: "openrouter", model: "openai/gpt-5.4" },
-      ],
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        query: "gpt-5.4",
+        count: 3,
+        matches: [
+          { provider: "openai", model: "gpt-5.4" },
+          { provider: "github-copilot", model: "gpt-5.4" },
+          { provider: "openrouter", model: "openai/gpt-5.4" },
+        ],
+      })
+    );
   });
 
   it("keeps provider catalog priority even when equally relevant variants differ by name", async () => {
@@ -164,15 +197,17 @@ describe("models command", () => {
 
     await runModels("gpt-5.4", undefined, { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      query: "gpt-5.4",
-      count: 2,
-      matches: [
-        { provider: "openai", model: "gpt-5.4-pro" },
-        { provider: "github-copilot", model: "gpt-5.4-mini" },
-      ],
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        query: "gpt-5.4",
+        count: 2,
+        matches: [
+          { provider: "openai", model: "gpt-5.4-pro" },
+          { provider: "github-copilot", model: "gpt-5.4-mini" },
+        ],
+      })
+    );
   });
 
   it("prints a helpful hint when global search returns no matches in text mode", async () => {
@@ -200,12 +235,14 @@ describe("models command", () => {
   it("prints model list for a specific provider in json mode", async () => {
     await runModels("anthropic", undefined, { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      provider: "anthropic",
-      count: 2,
-      models: ["claude-3-7-sonnet-20250219", "claude-opus-4-6"],
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        provider: "anthropic",
+        count: 2,
+        models: ["claude-3-7-sonnet-20250219", "claude-opus-4-6"],
+      })
+    );
   });
 
   it("throws a helpful error for unsupported providers when a provider filter is explicit", async () => {
@@ -236,6 +273,44 @@ describe("models command", () => {
       query: "gpt-5",
       count: 2,
       models: ["gpt-5", "gpt-5.4"],
+      overview: {
+        mode: "provider",
+        source: "pi-ai",
+        provider: "openai",
+        query: "gpt-5",
+        count: 2,
+      },
+      diagnostics: {
+        models: ["gpt-5", "gpt-5.4"],
+      },
+      guidance: {
+        nextStep: "obora models openai",
+      },
+    });
+  });
+
+  it("includes structured guidance for no-match global json responses", async () => {
+    await runModels("not-a-real-model", undefined, { json: true });
+
+    expect(formatter.json).toHaveBeenCalledWith({
+      source: "pi-ai",
+      query: "not-a-real-model",
+      count: 0,
+      matches: [],
+      hint: "No models matched. Check the spelling or try `obora models <provider> [query]`.",
+      overview: {
+        mode: "global",
+        source: "pi-ai",
+        query: "not-a-real-model",
+        count: 0,
+      },
+      diagnostics: {
+        matches: [],
+      },
+      guidance: {
+        nextStep: "obora models <provider> [query]",
+        hint: "No models matched. Check the spelling or try `obora models <provider> [query]`.",
+      },
     });
   });
 
@@ -252,78 +327,90 @@ describe("models command", () => {
 
     await runModels("openai", "gpt-5.4", { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      provider: "openai",
-      query: "gpt-5.4",
-      count: 3,
-      models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-pro"],
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        provider: "openai",
+        query: "gpt-5.4",
+        count: 3,
+        models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-pro"],
+      })
+    );
   });
 
   it("prints a helpful hint when provider filter returns no matches in json mode", async () => {
     await runModels("openai", "not-a-real-model", { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      provider: "openai",
-      query: "not-a-real-model",
-      count: 0,
-      models: [],
-      hint: "No models matched this provider filter. Check the query spelling or run `obora models 'not-a-real-model'`.",
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        provider: "openai",
+        query: "not-a-real-model",
+        count: 0,
+        models: [],
+        hint: "No models matched this provider filter. Check the query spelling or run `obora models 'not-a-real-model'`.",
+      })
+    );
   });
 
   it("uses a generic provider zero-match hint when the query is also a provider name", async () => {
     await runModels("openai", "anthropic", { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      provider: "openai",
-      query: "anthropic",
-      count: 0,
-      models: [],
-      hint: "No models matched this provider filter. Check the query spelling or search across all providers instead.",
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        provider: "openai",
+        query: "anthropic",
+        count: 0,
+        models: [],
+        hint: "No models matched this provider filter. Check the query spelling or search across all providers instead.",
+      })
+    );
   });
 
   it("uses the same generic hint for mixed-case provider-name queries", async () => {
     await runModels("openai", "Anthropic", { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      provider: "openai",
-      query: "Anthropic",
-      count: 0,
-      models: [],
-      hint: "No models matched this provider filter. Check the query spelling or search across all providers instead.",
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        provider: "openai",
+        query: "Anthropic",
+        count: 0,
+        models: [],
+        hint: "No models matched this provider filter. Check the query spelling or search across all providers instead.",
+      })
+    );
   });
 
   it("quotes multi-word provider filter hints so the suggested command stays valid", async () => {
     await runModels("openai", "claude opus", { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      provider: "openai",
-      query: "claude opus",
-      count: 0,
-      models: [],
-      hint: "No models matched this provider filter. Check the query spelling or run `obora models 'claude opus'`.",
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        provider: "openai",
+        query: "claude opus",
+        count: 0,
+        models: [],
+        hint: "No models matched this provider filter. Check the query spelling or run `obora models 'claude opus'`.",
+      })
+    );
   });
 
   it("shell-quotes special characters in provider zero-match fallback commands", async () => {
     await runModels("openai", "price $HOME", { json: true });
 
-    expect(formatter.json).toHaveBeenCalledWith({
-      source: "pi-ai",
-      provider: "openai",
-      query: "price $HOME",
-      count: 0,
-      models: [],
-      hint: "No models matched this provider filter. Check the query spelling or run `obora models 'price $HOME'`.",
-    });
+    expect(formatter.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pi-ai",
+        provider: "openai",
+        query: "price $HOME",
+        count: 0,
+        models: [],
+        hint: "No models matched this provider filter. Check the query spelling or run `obora models 'price $HOME'`.",
+      })
+    );
   });
 
   it("filters provider models by query in text mode", async () => {

--- a/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
+++ b/packages/cli/src/commands/__tests__/quickstart-e2e.test.ts
@@ -99,6 +99,28 @@ describe("CLI quickstart integration", () => {
           fallbackStub: true,
           nextPlaceToEdit: expect.stringContaining(".obora/config.yaml"),
         }),
+        overview: expect.objectContaining({
+          workflow: "quickstart-judge",
+          validated: true,
+          resolvedProvider: null,
+          resolvedModel: null,
+          fallbackStub: true,
+          nextStep: "obora run judge.yaml",
+        }),
+        diagnostics: expect.objectContaining({
+          resolution: expect.objectContaining({
+            fallbackStub: true,
+          }),
+          bindingPreview: expect.any(Array),
+          outputPreview: expect.any(Array),
+        }),
+        guidance: {
+          recommendations: ["Stub mode: configure auth with `obora doctor` before live execution."],
+          actions: [
+            { kind: "run", command: "obora doctor" },
+            { kind: "run", command: "obora run judge.yaml" },
+          ],
+        },
         bindingPreview: expect.arrayContaining([
           expect.objectContaining({
             stepName: "judge",
@@ -395,6 +417,10 @@ describe("CLI quickstart integration", () => {
     expect(stdout).toContain("Output Preview");
     expect(stdout).toContain("path <- artifacts/result.json [pending]");
     expect(stdout).toContain("schema <- artifacts/result.schema.json [resolved]");
-    expect(errorSpy).not.toHaveBeenCalled();
+
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(stderr).toContain(
+      "Stub mode: configure auth with `obora doctor` before live execution."
+    );
   });
 });

--- a/packages/cli/src/commands/__tests__/run.test.ts
+++ b/packages/cli/src/commands/__tests__/run.test.ts
@@ -440,6 +440,42 @@ describe("run command", () => {
       );
     });
 
+    it("should include overview, diagnostics, and guidance in dry-run JSON", async () => {
+      await runRun("judge.yaml", { dryRun: true, json: true });
+
+      expect(formatter.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overview: expect.objectContaining({
+            workflow: "loaded-workflow",
+            validated: true,
+            resolvedProvider: "none",
+            resolvedModel: "none",
+            fallbackStub: true,
+            bindingCount: 1,
+            outputCount: 1,
+            nextStep: "obora run judge.yaml",
+          }),
+          diagnostics: expect.objectContaining({
+            resolution: expect.objectContaining({
+              provider: "none",
+              fallbackStub: true,
+            }),
+            bindingPreview: expect.any(Array),
+            outputPreview: expect.any(Array),
+          }),
+          guidance: {
+            recommendations: [
+              "Stub mode: configure auth with `obora doctor` before live execution.",
+            ],
+            actions: [
+              { kind: "run", command: "obora doctor" },
+              { kind: "run", command: "obora run judge.yaml" },
+            ],
+          },
+        })
+      );
+    });
+
     it("should print resolution preview in dry-run text mode", async () => {
       await runRun("my-workflow", { dryRun: true });
 
@@ -452,6 +488,15 @@ describe("run command", () => {
       await runRun("judge.yaml", { dryRun: true });
 
       expect(formatter.info).toHaveBeenCalledWith("Next step: obora run judge.yaml");
+    });
+
+    it("should point to doctor before live execution when dry-run stays in stub mode", async () => {
+      await runRun("judge.yaml", { dryRun: true });
+
+      expect(formatter.warn).toHaveBeenCalledWith(
+        "Stub mode: configure auth with `obora doctor` before live execution."
+      );
+      expect(formatter.info).toHaveBeenCalledWith("Before live execution: obora doctor");
     });
 
     it("should print binding/output previews when available", async () => {

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -14,6 +14,19 @@ interface GlobalModelMatch {
   model: string;
 }
 
+interface ModelsOverview {
+  mode: "providers" | "provider" | "global";
+  source: "pi-ai";
+  count: number;
+  provider?: string;
+  query?: string;
+}
+
+interface ModelsGuidance {
+  nextStep: string;
+  hint?: string;
+}
+
 function buildGlobalNoMatchHint(): string {
   return `No models matched. Check the spelling or try \`obora models <provider> [query]\`.`;
 }
@@ -30,6 +43,70 @@ function buildProviderNoMatchHint(query: string, providers: string[]): string {
 
   const suggestedQuery = shellQuoteArg(query);
   return `No models matched this provider filter. Check the query spelling or run \`obora models ${suggestedQuery}\`.`;
+}
+
+function buildProviderOverview(provider: string, models: string[], query?: string): ModelsOverview {
+  return {
+    mode: "provider",
+    source: "pi-ai",
+    provider,
+    ...(query ? { query } : {}),
+    count: models.length,
+  };
+}
+
+function buildGlobalOverview(query: string, matches: GlobalModelMatch[]): ModelsOverview {
+  return {
+    mode: "global",
+    source: "pi-ai",
+    query,
+    count: matches.length,
+  };
+}
+
+function buildProvidersOverview(
+  providers: Array<{ provider: string; count: number }>
+): ModelsOverview {
+  return {
+    mode: "providers",
+    source: "pi-ai",
+    count: providers.length,
+  };
+}
+
+function buildProviderGuidance(
+  provider: string,
+  query: string | undefined,
+  models: string[]
+): ModelsGuidance {
+  return {
+    nextStep:
+      query && models.length > 0
+        ? `obora models ${provider}`
+        : `obora models ${provider}${query ? "" : " <query>"}`,
+    ...(query && models.length === 0
+      ? { hint: `No matches yet. Inspect the full ${provider} catalog or broaden the query.` }
+      : {}),
+  };
+}
+
+function buildGlobalGuidance(query: string, matches: GlobalModelMatch[]): ModelsGuidance {
+  if (matches.length === 0) {
+    return {
+      nextStep: "obora models <provider> [query]",
+      hint: buildGlobalNoMatchHint(),
+    };
+  }
+
+  return {
+    nextStep: `obora models ${matches[0]!.provider} ${query}`,
+  };
+}
+
+function buildProvidersGuidance(): ModelsGuidance {
+  return {
+    nextStep: "obora models <provider> [query]",
+  };
 }
 
 function naturalCompare(a: string, b: string): number {
@@ -142,6 +219,8 @@ function printGlobalMatches(
   query: string,
   options: ModelsOptions
 ): void {
+  const guidance = buildGlobalGuidance(query, matches);
+
   if (options.json) {
     formatter.json({
       source: "pi-ai",
@@ -149,6 +228,9 @@ function printGlobalMatches(
       count: matches.length,
       matches,
       ...(matches.length === 0 ? { hint: buildGlobalNoMatchHint() } : {}),
+      overview: buildGlobalOverview(query, matches),
+      diagnostics: { matches },
+      guidance,
     });
     return;
   }
@@ -159,12 +241,14 @@ function printGlobalMatches(
   formatter.step(`Match count: ${matches.length}`);
   if (matches.length === 0) {
     formatter.warn(buildGlobalNoMatchHint());
+    formatter.info(`Next step: ${guidance.nextStep}`);
     return;
   }
 
   for (const match of matches) {
     formatter.step(`${match.provider}: ${match.model}`);
   }
+  formatter.info(`Next step: ${guidance.nextStep}`);
 }
 
 export async function runModels(
@@ -187,6 +271,7 @@ export async function runModels(
 
   if (provider) {
     const models = filterModels(listPiAIModels(provider), query);
+    const guidance = buildProviderGuidance(provider, query, models);
 
     if (options.json) {
       formatter.json({
@@ -198,6 +283,14 @@ export async function runModels(
         ...(models.length === 0 && query
           ? { hint: buildProviderNoMatchHint(query, providers) }
           : {}),
+        overview: buildProviderOverview(provider, models, query),
+        diagnostics: { models },
+        guidance: {
+          ...guidance,
+          ...(models.length === 0 && query
+            ? { hint: buildProviderNoMatchHint(query, providers) }
+            : {}),
+        },
       });
       return;
     }
@@ -211,12 +304,14 @@ export async function runModels(
     formatter.step(`Model count: ${models.length}`);
     if (models.length === 0 && query) {
       formatter.warn(buildProviderNoMatchHint(query, providers));
+      formatter.info(`Next step: ${guidance.nextStep}`);
       return;
     }
 
     for (const model of models) {
       formatter.step(model);
     }
+    formatter.info(`Next step: ${guidance.nextStep}`);
     return;
   }
 
@@ -224,11 +319,15 @@ export async function runModels(
     provider: name,
     count: listPiAIModels(name).length,
   }));
+  const guidance = buildProvidersGuidance();
 
   if (options.json) {
     formatter.json({
       source: "pi-ai",
       providers: providerRows,
+      overview: buildProvidersOverview(providerRows),
+      diagnostics: { providers: providerRows },
+      guidance,
     });
     return;
   }
@@ -239,7 +338,7 @@ export async function runModels(
   for (const row of providerRows) {
     formatter.step(`${row.provider} (${row.count})`);
   }
-  formatter.info("Next step: obora models <provider> [query] or obora models <query>");
+  formatter.info(`Next step: ${guidance.nextStep}`);
 }
 
 export function createModelsCommand(): Command {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -55,6 +55,16 @@ const DEBUG_EVENT_TYPES = [
   "knowledge_context_attached",
 ] as const;
 
+interface RunGuidanceAction {
+  kind: "run";
+  command: string;
+}
+
+interface DryRunGuidance {
+  recommendations: string[];
+  actions: RunGuidanceAction[];
+}
+
 function clipDebug(value: unknown, max = 180): string {
   if (value === undefined || value === null) return "";
   const text = typeof value === "string" ? value : JSON.stringify(value);
@@ -106,6 +116,66 @@ function summarizeDebugEvent(type: string, data: Record<string, unknown> | undef
     default:
       return clipDebug(data);
   }
+}
+
+function buildDryRunGuidance(
+  workflowCommand: string,
+  resolutionSummary: {
+    fallbackStub: boolean;
+  }
+): DryRunGuidance {
+  const actions: RunGuidanceAction[] = [{ kind: "run", command: `obora run ${workflowCommand}` }];
+  const recommendations: string[] = [];
+
+  if (resolutionSummary.fallbackStub) {
+    actions.unshift({ kind: "run", command: "obora doctor" });
+    recommendations.push("Stub mode: configure auth with `obora doctor` before live execution.");
+  } else {
+    recommendations.push("Dry run passed. Start live execution when ready.");
+  }
+
+  return { recommendations, actions };
+}
+
+function buildDryRunOverview(
+  workflowName: string,
+  workflowCommand: string,
+  resolutionSummary: {
+    provider: string | null;
+    model: string | null;
+    fallbackStub: boolean;
+  },
+  bindingPreviewEntries: unknown[],
+  outputPreviewEntries: unknown[]
+): Record<string, unknown> {
+  return {
+    workflow: workflowName,
+    validated: true,
+    resolvedProvider: resolutionSummary.provider,
+    resolvedModel: resolutionSummary.model,
+    fallbackStub: resolutionSummary.fallbackStub,
+    bindingCount: bindingPreviewEntries.length,
+    outputCount: outputPreviewEntries.length,
+    nextStep: `obora run ${workflowCommand}`,
+  };
+}
+
+function buildDryRunDiagnostics(
+  resolutionSummary: Record<string, unknown>,
+  bindingPreviewEntries: unknown[],
+  outputPreviewEntries: unknown[],
+  extras: {
+    expandedWorkflow?: unknown;
+    stopSemantics?: unknown;
+  } = {}
+): Record<string, unknown> {
+  return {
+    resolution: resolutionSummary,
+    bindingPreview: bindingPreviewEntries,
+    outputPreview: outputPreviewEntries,
+    ...(extras.expandedWorkflow !== undefined ? { expandedWorkflow: extras.expandedWorkflow } : {}),
+    ...(extras.stopSemantics !== undefined ? { stopSemantics: extras.stopSemantics } : {}),
+  };
 }
 
 export async function runRun(workflow: string, options: Record<string, unknown>): Promise<void> {
@@ -285,6 +355,24 @@ export async function runRun(workflow: string, options: Record<string, unknown>)
   }
 
   if (options.dryRun) {
+    const guidance = buildDryRunGuidance(workflow, resolutionSummary);
+    const overview = buildDryRunOverview(
+      workflowName,
+      workflow,
+      resolutionSummary,
+      bindingPreviewEntries,
+      outputPreviewEntries
+    );
+    const diagnostics = buildDryRunDiagnostics(
+      resolutionSummary,
+      bindingPreviewEntries,
+      outputPreviewEntries,
+      {
+        ...(options.dumpExpandedWorkflow ? { expandedWorkflow } : {}),
+        ...(options.showStopSemantics ? { stopSemantics } : {}),
+      }
+    );
+
     if (isJsonOutput(options)) {
       formatter.json({
         workflow: workflowName,
@@ -292,6 +380,9 @@ export async function runRun(workflow: string, options: Record<string, unknown>)
         resolution: resolutionSummary,
         bindingPreview: bindingPreviewEntries,
         outputPreview: outputPreviewEntries,
+        overview,
+        diagnostics,
+        guidance,
         ...(options.dumpExpandedWorkflow ? { expandedWorkflow } : {}),
         ...(options.showStopSemantics ? { stopSemantics } : {}),
         elapsedMs: Date.now() - startedAt,
@@ -307,6 +398,10 @@ export async function runRun(workflow: string, options: Record<string, unknown>)
         formatter.json(stopSemantics);
       }
       formatter.info("Dry run preview complete. No execution was started.");
+      if (resolutionSummary.fallbackStub) {
+        formatter.warn("Stub mode: configure auth with `obora doctor` before live execution.");
+        formatter.info("Before live execution: obora doctor");
+      }
       formatter.info(`Next step: obora run ${workflow}`);
       if (isVerboseOutput(options)) {
         formatter.info(`Validation completed in ${Date.now() - startedAt}ms`);


### PR DESCRIPTION
## Summary
- add overview/diagnostics/guidance sections to `models` JSON output
- add structured dry-run guidance and stub-mode next-step messaging to `run`
- cover the new contracts in models/run/quickstart tests

## Testing
- pnpm --filter @obora/cli test
- pnpm --filter @obora/cli build
- pnpm --filter @obora/cli lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `models` and `run` commands with richer JSON output including structured `overview`, `diagnostics`, and `guidance` sections.
  * Added guidance messages recommending configuration steps when in stub mode during dry-run execution.

* **Tests**
  * Updated test assertions to validate new response structure and fields across all affected commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->